### PR TITLE
DOCSTOOLS-291: add the write permission for files in the tmp folder

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ shell.mkdir(tmpInputFolder, tmpOutputFolder);
  * Please, change files only in temporary folders.
  */
 shell.cp('-r', resolve(_yargs.argv.input, '*'), tmpInputFolder);
+shell.chmod('-R', 'u+w', tmpInputFolder);
 
 ArgvService.init({
     ..._yargs.argv,


### PR DESCRIPTION
When copying, permissions for files and directories can be saved.
If the sources have read-only permission, an error occurs
when deleting excluded files.