### PR TITLE
DOCSTOOLS-336: add support for one file mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1248,6 +1248,12 @@
       "integrity": "sha512-Q7DYAOi9O/+cLLhdaSvKdaumWyHbm7HAk/bFwwyTuU0arR5yyCeW5GOoqt4tJTpDRxhpx9Q8kQL6vMpuw9hDSw==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.167",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.167.tgz",
+      "integrity": "sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw==",
+      "dev": true
+    },
     "@types/markdown-it": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-10.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1184,9 +1184,9 @@
       }
     },
     "@doc-tools/transform": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@doc-tools/transform/-/transform-1.5.0.tgz",
-      "integrity": "sha512-4qX2h7uoF3vboO/xH8yVDINhKtikTNGOQbuRFsOzgAUspbhD5bS5sHSGfI09OAzw1SSHiCus5dsflnenEez29g==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@doc-tools/transform/-/transform-1.5.1.tgz",
+      "integrity": "sha512-WJJ9VZb69xNhuXUnpf8jxGF2q/m/XV82iaYhJlfOKrM/ONfGjm9iJoWjYb9K1NetRem5vnBggJIhOtLlS5oDjQ==",
       "requires": {
         "chalk": "^4.0.0",
         "highlight.js": "^10.0.3",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@babel/preset-react": "^7.9.4",
     "@babel/preset-typescript": "^7.9.0",
     "@types/chalk": "^2.2.0",
+    "@types/lodash": "^4.14.167",
     "@types/js-yaml": "^4.0.0",
     "@types/markdown-it": "^10.0.0",
     "@types/mime-types": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@doc-tools/components": "^1.5.3",
-    "@doc-tools/transform": "^1.5.0",
+    "@doc-tools/transform": "^1.5.1",
     "aws-sdk": "^2.773.0",
     "chalk": "^4.0.0",
     "js-yaml": "^4.0.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ export const BUNDLE_FILENAME = 'app.js';
 export const TMP_INPUT_FOLDER = '.tmp_input';
 export const TMP_OUTPUT_FOLDER = '.tmp_output';
 export const MAIN_TIMER_ID = 'Build time';
+export const SINGLE_PAGE_FOLDER = '_single_page';
 
 export enum Stage {
     NEW = 'new',

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,9 +74,9 @@ const _yargs = yargs
         describe: 'Run in quiet mode. Don\'t write logs to stdout',
         type: 'boolean',
     })
-    .option('singlePage', {
+    .option('single-page', {
         default: false,
-        describe: 'Build a single page in the output folder also',
+        describe: 'Beta functionality: Build a single page in the output folder also',
         type: 'boolean',
     })
     .option('publish', {

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,11 @@ const _yargs = yargs
         describe: 'Run in quiet mode. Don\'t write logs to stdout',
         type: 'boolean',
     })
+    .option('singlePage', {
+        default: false,
+        describe: 'Build a single page in the output folder also',
+        type: 'boolean',
+    })
     .option('publish', {
         default: false,
         describe: 'Should upload output files to S3 storage',

--- a/src/models.ts
+++ b/src/models.ts
@@ -14,6 +14,7 @@ export interface YfmConfig {
     resolveConditions: boolean;
     strict: boolean;
     ignoreStage: string;
+    singlePage: boolean;
 }
 
 export interface YfmArgv extends YfmConfig {
@@ -42,6 +43,7 @@ export interface YfmToc extends Filter {
     title?: string;
     include?: YfmTocInclude;
     id?: string;
+    singlePage?: boolean;
 }
 
 export interface YfmTocInclude {
@@ -68,4 +70,9 @@ export interface LeadingPageLinks extends Filter {
 export interface Filter {
     when?: boolean|string;
     [key: string]: unknown;
+}
+
+export interface SinglePageResult {
+    path: string;
+    content: string;
 }

--- a/src/resolvers/md2md.ts
+++ b/src/resolvers/md2md.ts
@@ -10,7 +10,7 @@ import {getPlugins} from '../utils';
 
 function transformMd2Md(input: string, options: ResolverOptions) {
     const {applyPresets, resolveConditions} = ArgvService.getConfig();
-    const {vars = {}, path, root, destPath, destRoot, collectOfPlugins, log, copyFile} = options;
+    const {vars = {}, path, root, destPath, destRoot, collectOfPlugins, log, copyFile, singlePage} = options;
     let output = liquid(input, vars, path, {
         conditions: resolveConditions,
         substitutions: applyPresets,
@@ -26,6 +26,7 @@ function transformMd2Md(input: string, options: ResolverOptions) {
             log,
             copyFile,
             collectOfPlugins,
+            singlePage,
         });
     }
 
@@ -40,6 +41,7 @@ export interface ResolverOptions {
     path: string;
     log: Logger;
     copyFile: (targetPath: string, targetDestPath: string, options?: ResolverOptions) => void;
+    singlePage?: boolean;
     root?: string;
     destPath?: string;
     destRoot?: string;
@@ -68,13 +70,17 @@ function makeCollectOfPlugins(plugins: Plugin[]) {
     };
 }
 
+export interface ResolveMd2MdOptions {
+    inputPath: string;
+    outputPath: string;
+    singlePage?: boolean;
+}
 /**
  * Transforms raw markdown file to public markdown document.
- * @param inputPath
- * @param outputPath
+ * @param ResolveMd2MdOptions
  * @return {string}
  */
-export function resolveMd2Md(inputPath: string, outputPath: string): string {
+export function resolveMd2Md({inputPath, outputPath, singlePage}: ResolveMd2MdOptions): string {
     const {input, output, vars} = ArgvService.getConfig();
     const resolvedInputPath = resolve(input, inputPath);
     const content: string = readFileSync(resolvedInputPath, 'utf8');
@@ -88,6 +94,7 @@ export function resolveMd2Md(inputPath: string, outputPath: string): string {
         root: resolve(input),
         destRoot: resolve(output),
         collectOfPlugins,
+        singlePage,
         vars: {
             ...PresetService.get(dirname(inputPath)),
             ...vars,

--- a/src/services/tocs.ts
+++ b/src/services/tocs.ts
@@ -1,17 +1,19 @@
 import {dirname, join, parse, resolve} from 'path';
-import {copyFileSync, readFileSync, writeFileSync} from 'fs';
-import {load, dump} from 'js-yaml';
+import {copyFileSync, readFileSync, writeFileSync, existsSync} from 'fs';
+import {safeLoad, safeDump} from 'js-yaml';
 import shell from 'shelljs';
 import walkSync from 'walk-sync';
 import liquid from '@doc-tools/transform/lib/liquid';
 import log from '@doc-tools/transform/lib/log';
+import {getSinglePageAnchorId} from '@doc-tools/transform/lib/utils';
 import {bold} from 'chalk';
 
 import {ArgvService, PresetService} from './index';
 import {YfmToc} from '../models';
-import {Stage} from '../constants';
+import {Stage, SINGLE_PAGE_FOLDER} from '../constants';
 import {isExternalHref} from '../utils';
 import {filterFiles} from './utils';
+import {cloneDeep as _cloneDeep} from 'lodash';
 
 const storage: Map<string, YfmToc> = new Map();
 const navigationPaths: string[] = [];
@@ -22,11 +24,12 @@ function add(path: string) {
         output: outputFolderPath,
         outputFormat,
         ignoreStage,
+        singlePage,
     } = ArgvService.getConfig();
 
     const pathToDir = dirname(path);
     const content = readFileSync(resolve(inputFolderPath, path), 'utf8');
-    const parsedToc = load(content) as YfmToc;
+    const parsedToc = safeLoad(content) as YfmToc;
 
     // Should ignore toc with specified stage.
     if (parsedToc.stage === ignoreStage) {
@@ -54,46 +57,34 @@ function add(path: string) {
         log.error(`Error while filtering toc file: ${path}. Error message: ${error}`);
     }
 
-    if (outputFormat === 'md') {
-        /* Should copy resolved and filtered toc to output folder */
-        const outputPath = resolve(outputFolderPath, path);
-        const outputToc = dump(parsedToc);
-        shell.mkdir('-p', dirname(outputPath));
-        writeFileSync(outputPath, outputToc);
-    }
-
     /* Store parsed toc for .md output format */
     storage.set(path, parsedToc);
 
     /* Store path to toc file to handle relative paths in navigation */
     parsedToc.base = pathToDir;
 
-    const navigationItemQueue = [parsedToc];
+    if (outputFormat === 'md') {
+        /* Should copy resolved and filtered toc to output folder */
+        const outputPath = resolve(outputFolderPath, path);
+        const outputToc = safeDump(parsedToc);
+        shell.mkdir('-p', dirname(outputPath));
+        writeFileSync(outputPath, outputToc);
 
-    while (navigationItemQueue.length) {
-        const navigationItem = navigationItemQueue.shift();
+        if (singlePage) {
+            const parsedSinglePageToc = _cloneDeep(parsedToc);
+            const currentPath = resolve(outputFolderPath, path);
+            prepareTocForSinglePageMode(parsedSinglePageToc, {root: outputFolderPath, currentPath});
 
-        if (!navigationItem) {
-            continue;
-        }
+            const outputSinglePageDir = resolve(dirname(outputPath), SINGLE_PAGE_FOLDER);
+            const outputSinglePageTocPath = resolve(outputSinglePageDir, 'toc.yaml');
+            const outputSinglePageToc = safeDump(parsedSinglePageToc);
 
-        if (navigationItem.items) {
-            const items = navigationItem.items.map(((item: YfmToc, index: number) => {
-                // Generate personal id for each navigation item
-                item.id = `${item.name}-${index}-${Math.random()}`;
-                return item;
-            }));
-            navigationItemQueue.push(...items);
-        }
-
-        if (navigationItem.href && !isExternalHref(navigationItem.href)) {
-            const href = `${pathToDir}/${navigationItem.href}`;
-            storage.set(href, parsedToc);
-
-            const navigationPath = _normalizeHref(href);
-            navigationPaths.push(navigationPath);
+            shell.mkdir('-p', outputSinglePageDir);
+            writeFileSync(outputSinglePageTocPath, outputSinglePageToc);
         }
     }
+
+    prepareNavigationPaths(parsedToc, pathToDir);
 }
 
 function getForPath(path: string): YfmToc|undefined {
@@ -102,6 +93,50 @@ function getForPath(path: string): YfmToc|undefined {
 
 function getNavigationPaths(): string[] {
     return [...navigationPaths];
+}
+
+function prepareNavigationPaths(parsedToc: YfmToc, pathToDir: string) {
+    function processItems(items: YfmToc[], pathToDir: string) {
+        items.forEach((item) => {
+            if (!parsedToc.singlePage && item.items) {
+                const preparedSubItems = item.items.map(((item: YfmToc, index: number) => {
+                    // Generate personal id for each navigation item
+                    item.id = `${item.name}-${index}-${Math.random()}`;
+                    return item;
+                }));
+                processItems(preparedSubItems, pathToDir);
+            }
+
+            if (item.href && !isExternalHref(item.href)) {
+                const href = `${pathToDir}/${item.href}`;
+                storage.set(href, parsedToc);
+
+                const navigationPath = _normalizeHref(href);
+                navigationPaths.push(navigationPath);
+            }
+        });
+    }
+
+    processItems([parsedToc], pathToDir);
+}
+
+function prepareTocForSinglePageMode(parsedToc: YfmToc, options: {root: string; currentPath: string}) {
+    const {root, currentPath} = options;
+
+    function processItems(items: YfmToc[]) {
+        items.forEach((item) => {
+            if (item.items) {
+                processItems(item.items);
+            }
+
+            if (item.href && !isExternalHref(item.href)) {
+                item.href = getSinglePageAnchorId({root, currentPath, pathname: item.href});
+            }
+        });
+    }
+
+    processItems(parsedToc.items);
+    parsedToc.singlePage = true;
 }
 
 /**
@@ -189,7 +224,7 @@ function _replaceIncludes(items: YfmToc[], tocDir: string, sourcesDir: string, v
             const includeTocPath = resolve(sourcesDir, path);
 
             try {
-                const includeToc = load(readFileSync(includeTocPath, 'utf8')) as YfmToc;
+                const includeToc = safeLoad(readFileSync(includeTocPath, 'utf8')) as YfmToc;
 
                 // Should ignore included toc with tech-preview stage.
                 if (includeToc.stage === Stage.TECH_PREVIEW) {
@@ -214,8 +249,27 @@ function _replaceIncludes(items: YfmToc[], tocDir: string, sourcesDir: string, v
     }, [] as YfmToc[]);
 }
 
+function getTocDir(pagePath: string): string {
+    const {output: outputFolderPath} = ArgvService.getConfig();
+
+    const tocDir = dirname(pagePath);
+    const tocPath = resolve(tocDir, 'toc.yaml');
+
+
+    if (!tocDir.includes(outputFolderPath)) {
+        throw new Error('Error while finding toc dir');
+    }
+
+    if (existsSync(tocPath)) {
+        return tocDir;
+    }
+
+    return getTocDir(tocDir);
+}
+
 export default {
     add,
     getForPath,
     getNavigationPaths,
+    getTocDir,
 };

--- a/src/services/tocs.ts
+++ b/src/services/tocs.ts
@@ -1,6 +1,6 @@
 import {dirname, join, parse, resolve} from 'path';
 import {copyFileSync, readFileSync, writeFileSync, existsSync} from 'fs';
-import {safeLoad, safeDump} from 'js-yaml';
+import {load, dump} from 'js-yaml';
 import shell from 'shelljs';
 import walkSync from 'walk-sync';
 import liquid from '@doc-tools/transform/lib/liquid';
@@ -29,7 +29,7 @@ function add(path: string) {
 
     const pathToDir = dirname(path);
     const content = readFileSync(resolve(inputFolderPath, path), 'utf8');
-    const parsedToc = safeLoad(content) as YfmToc;
+    const parsedToc = load(content) as YfmToc;
 
     // Should ignore toc with specified stage.
     if (parsedToc.stage === ignoreStage) {
@@ -66,7 +66,7 @@ function add(path: string) {
     if (outputFormat === 'md') {
         /* Should copy resolved and filtered toc to output folder */
         const outputPath = resolve(outputFolderPath, path);
-        const outputToc = safeDump(parsedToc);
+        const outputToc = dump(parsedToc);
         shell.mkdir('-p', dirname(outputPath));
         writeFileSync(outputPath, outputToc);
 
@@ -77,7 +77,7 @@ function add(path: string) {
 
             const outputSinglePageDir = resolve(dirname(outputPath), SINGLE_PAGE_FOLDER);
             const outputSinglePageTocPath = resolve(outputSinglePageDir, 'toc.yaml');
-            const outputSinglePageToc = safeDump(parsedSinglePageToc);
+            const outputSinglePageToc = dump(parsedSinglePageToc);
 
             shell.mkdir('-p', outputSinglePageDir);
             writeFileSync(outputSinglePageTocPath, outputSinglePageToc);
@@ -224,7 +224,7 @@ function _replaceIncludes(items: YfmToc[], tocDir: string, sourcesDir: string, v
             const includeTocPath = resolve(sourcesDir, path);
 
             try {
-                const includeToc = safeLoad(readFileSync(includeTocPath, 'utf8')) as YfmToc;
+                const includeToc = load(readFileSync(includeTocPath, 'utf8')) as YfmToc;
 
                 // Should ignore included toc with tech-preview stage.
                 if (includeToc.stage === Stage.TECH_PREVIEW) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import {relative, dirname, basename, extname, format, join} from 'path';
 import {blue, green} from 'chalk';
 
-import {YfmToc} from './models';
+import {YfmToc, SinglePageResult} from './models';
 import {YFM_PLUGINS} from './constants';
 import {ArgvService} from './services';
 
@@ -43,7 +43,7 @@ export function transformToc(toc: YfmToc|null, pathToFileDirectory: string): Yfm
             const filename: string = basename(href, fileExtension);
             const transformedFilename: string = format({
                 name: filename,
-                ext: '.html',
+                ext: toc.singlePage ? '' : '.html',
             });
 
             navigationItem.href = join(pathToIndexDirectory, dirname(href), transformedFilename);
@@ -123,3 +123,10 @@ export function getPlugins() {
 export function isExternalHref(href: string) {
     return href.startsWith('http') || href.startsWith('//');
 }
+
+export const joinSinglePageResults = (singlePageResults: SinglePageResult[]) => {
+    const delimeter = '\n\n<hr class="yfm-page__delimeter">\n\n';
+    return singlePageResults.map((page) => {
+        return page.content;
+    }).join(delimeter);
+};


### PR DESCRIPTION
# Поддержка одностраничника

C флагом  --single-page собирается традиционная и одностраничная версия документации. Одностраничная версия будет лежать рядом с toc.yaml файлом в директории _single_page. Построение одностраничной версии происходит на этапе md2md. Производится исправление  якорей и добавление новых, исправление ссылок на другие md файлы, ccылок на ассеты и инклуды, понижение уровня заголовков. В результате, _single_page содержит index.md файл, полностью готовый для рендера в html, измененный toc.yaml и директории с ассетами и инклудами как они лежат в традиционной версии.  Новый toc.yaml содержит разделы с href не на файл, а на хеш на начало этой страницы в одностраничнике.  Эти хешы проставляются в плагины якорей в collect-функции плагина

Все преобразования md файлов выполняет yfm-transform в collect-функциях плагинов https://github.com/yandex-cloud/yfm-transform/pull/28. collect-функции плагинов получают на вход исходник в виде строки, происходит поиск и копирование ассетов и инклудов. Так же collect-функции могут возвращать измененную строку, таким образом происходят преобразование для одностраничника.

Есть также возможность собрать одностраничник без этапа md2md. Этот этап выполнится за пользователя на временной директории.