### PR TITLE
feat: support pluggable lint rules

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 import {plugins} from '@doc-tools/transform';
+import preprocessLintRules from '@doc-tools/transform/lib/lintRules/preprocessRules';
 import {dirname} from 'path';
 
 export const BUILD_FOLDER = 'build';
@@ -40,6 +41,12 @@ export const YFM_PLUGINS = [
     sup,
     video,
 ];
+
+const {inlineCodeMaxLen, titleSyntax} = preprocessLintRules;
+export const YFM_PREPROCESS_LINT_RULES = [
+    inlineCodeMaxLen,
+    titleSyntax,
+].filter(Boolean);
 
 export const PROCESSING_HAS_BEEN_FINISHED = 'Processing file has been finished:';
 export const ALL_CONTRIBUTORS_HAS_BEEN_RECEIVED = 'All contributors have been received.';

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,11 @@ const _yargs = yargs
         describe: 'Should upload output files to S3 storage',
         type: 'boolean',
     })
+    .option('disable-lint', {
+        default: false,
+        describe: 'Disable lint checks',
+        type: 'boolean',
+    })
     .check(argvValidator)
     .example('yfm -i ./input -o ./output', '')
     .demandOption(['input', 'output'], 'Please provide input and output arguments to work with this tool')

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,5 +1,6 @@
 import {FileContributors, VCSConnector, VCSConnectorConfig} from './vcs-connector/models';
 import {Stage} from './constants';
+import {LintRulesOptions} from '@doc-tools/transform/lib/lintRules/models';
 
 export type VarsPreset = 'internal'|'external';
 
@@ -21,6 +22,8 @@ interface YfmConfig {
     ignoreStage: string;
     singlePage: boolean;
     connector?: VCSConnectorConfig;
+    disableLint: boolean;
+    lintOptions: LintRulesOptions;
 }
 
 export interface YfmArgv extends YfmConfig {

--- a/src/resolvers/md2html.ts
+++ b/src/resolvers/md2html.ts
@@ -77,7 +77,7 @@ function YamlFileTransformer(content: string): Object {
 }
 
 function MdFileTransformer(content: string, transformOptions: FileTransformOptions): Output {
-    const {input, vars, ...options} = ArgvService.getConfig();
+    const {input, vars, lintOptions, disableLint, ...options} = ArgvService.getConfig();
     const {path} = transformOptions;
     const resolvedPath: string = resolve(input, path);
 
@@ -87,6 +87,8 @@ function MdFileTransformer(content: string, transformOptions: FileTransformOptio
     return transform(content, {
         ...options,
         plugins: getPlugins(),
+        lintOptions,
+        disableLint,
         vars: {
             ...PresetService.get(dirname(path)),
             ...vars,

--- a/src/services/tocs.ts
+++ b/src/services/tocs.ts
@@ -205,7 +205,9 @@ function _liquidSubstitutions(input: string, vars: Record<string, string>, path:
         return input;
     }
 
-    return liquid(input, vars, path, {
+    return liquid(input, {
+        vars,
+        path,
         conditions: false,
         substitutions: true,
     });


### PR DESCRIPTION
Зависит от yfm-transform: https://github.com/yandex-cloud/yfm-transform/pull/56

В `.yfm` файле можно указать конфиг с опциями для правил

```
lintOptions:
  unreachable-link:
    level: warn
  inline-code-max-len:
    value: 80
  liquid-variable-not-found:
    level: error
```

Можно указать в cli флаг disable-lint=true, чтобы не проверять то, что было уже проверено на предыдущем этапе
preprocessLintRules проверяют контент файла на синтаксис  на md2md, и на md2html
