### PR TITLE
fix(includers/openapi): openapi generator skips path without tags

### DIFF
--- a/src/services/includers/batteries/openapi/generators/main.ts
+++ b/src/services/includers/batteries/openapi/generators/main.ts
@@ -7,9 +7,10 @@ import {
     TAGS_SECTION_NAME,
 } from '../constants';
 
-import {Info, Contact, ContactSource, Tag} from '../types';
+import {Info, Contact, ContactSource, Tag, Specification} from '../types';
+import {mdPath, sectionName} from '../index';
 
-function main(info: Info, tags: Map<string, Tag>) {
+function main(info: Info, spec: Specification) {
     const license = info.license?.url ? link : body;
 
     const page = [
@@ -19,7 +20,7 @@ function main(info: Info, tags: Map<string, Tag>) {
         info.license && license(info.license.name, info.license.url as string),
         description(info.description),
         contact(info.contact),
-        sections(tags),
+        sections(spec),
     ];
 
     return block(page);
@@ -42,11 +43,13 @@ function description(text?: string) {
     return text?.length && block([title(2)(DESCRIPTION_SECTION_NAME), body(text)]);
 }
 
-function sections(tags: Map<string, Tag>) {
+function sections({tags, endpoints}: Specification) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
     const links = Array.from(tags).map(([_, {name, id}]: [any, Tag]) => link(name, id + sep + 'index.md'));
 
-    return tags?.size && block([title(2)(TAGS_SECTION_NAME), list(links)]);
+    links.push(...endpoints.map((e) => link(sectionName(e), mdPath(e))));
+
+    return links.length && block([title(2)(TAGS_SECTION_NAME), list(links)]);
 }
 
 export {main};

--- a/src/services/includers/batteries/openapi/types.ts
+++ b/src/services/includers/batteries/openapi/types.ts
@@ -50,6 +50,7 @@ export type Endpoints = Endpoint[];
 
 export type Endpoint = {
     id: string;
+    operationId?: string;
     method: Method;
     path: string;
     tags: string[];
@@ -58,6 +59,11 @@ export type Endpoint = {
     servers: string[];
     parameters?: Parameters;
     responses?: Responses;
+};
+
+export type Specification = {
+    tags: Map<string, Tag>;
+    endpoints: Endpoints;
 };
 
 export const methods = [


### PR DESCRIPTION
Creating section for paths without tags.
Result example for merchant openapi:
![Снимок экрана 2022-12-20 в 20 56 07](https://user-images.githubusercontent.com/3672471/208734061-eb304c89-0ea4-414f-8fa0-55a6a553c0b8.png)
