### PR TITLE
feat(includers/openapi): endpoint render server description

### DIFF
--- a/src/services/includers/batteries/openapi/generators/endpoint.ts
+++ b/src/services/includers/batteries/openapi/generators/endpoint.ts
@@ -17,6 +17,8 @@ import {
     Schema,
     Method,
     Refs,
+    Server,
+    Servers,
 } from '../types';
 import stringify from 'json-stringify-safe';
 import {prepareTableRowData, prepareSampleObject, tableFromSchema, tableParameterName} from './traverse';
@@ -36,13 +38,27 @@ function endpoint(allRefs: Refs, data: Endpoint) {
     return block(page);
 }
 
-function request(path: string, method: Method, servers: string[]) {
-    const requestsTable = table([
-        ['method', 'url'],
-        [method, block(servers.map((href) => code(href + '/' + path)))],
+function request(path: string, method: Method, servers: Servers) {
+    const requestTableCols = ['method', 'url'];
+
+    const hrefs = block(servers.map(({url}) => code(url + '/' + path)));
+
+    const requestTableRow = [code(method), hrefs];
+
+    if (servers.every((server: Server) => server.description)) {
+        requestTableCols.push('description');
+
+        const descriptions = block(servers.map(({description}) => code(description as string)));
+
+        requestTableRow.push(descriptions);
+    }
+
+    const requestTable = table([
+        requestTableCols,
+        requestTableRow,
     ]);
 
-    return block([title(2)(REQUEST_SECTION_NAME), requestsTable]);
+    return block([title(2)(REQUEST_SECTION_NAME), requestTable]);
 }
 
 function parameters(params?: Parameters) {

--- a/src/services/includers/batteries/openapi/parsers.ts
+++ b/src/services/includers/batteries/openapi/parsers.ts
@@ -115,8 +115,12 @@ function paths(spec: OpenapiSpec, tagsByID: Map<string, Tag>): Specification {
         const opid = (path: string, method: string, id?: string) =>
             slugify(id ?? ([path, method].join('-')));
 
-        const serverURLs = (endpoint.servers || servers || [{url: '/'}])
-            .map(({url}: Server) => trimSlash(url));
+        const parsedServers = (endpoint.servers || servers || [{url: '/'}])
+            .map((server: Server) => {
+                server.url = trimSlash(server.url);
+
+                return server;
+            });
 
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
         const parseResponse = ([code, response]: [string, {[key: string]: any}]) => {
@@ -138,7 +142,7 @@ function paths(spec: OpenapiSpec, tagsByID: Map<string, Tag>): Specification {
         const contentType = requestBody ? Object.keys(requestBody.content)[0] : undefined;
 
         const parsedEndpoint: Endpoint = {
-            servers: serverURLs,
+            servers: parsedServers,
             responses: parsedResponses,
             parameters,
             summary,

--- a/src/services/includers/batteries/openapi/types.ts
+++ b/src/services/includers/batteries/openapi/types.ts
@@ -59,7 +59,7 @@ export type Endpoint = {
     tags: string[];
     summary?: string;
     description?: string;
-    servers: string[];
+    servers: Servers;
     parameters?: Parameters;
     responses?: Responses;
     requestBody?: Schema;
@@ -87,6 +87,7 @@ export type Servers = Server[];
 
 export type Server = {
     url: string;
+    description?: string;
 };
 
 export type Parameters = Parameter[];


### PR DESCRIPTION
preserve server description during Server object parsing

render server description inside the endpoint pages.