### PR TITLE
fix(includers/openapi): delete Description title

### DIFF
--- a/src/services/includers/batteries/openapi/constants.ts
+++ b/src/services/includers/batteries/openapi/constants.ts
@@ -1,7 +1,6 @@
 const EOL = '\n';
 const TAG_NAMES_FIELD = 'x-navtitle';
 const BLOCK = EOL.repeat(2);
-const DESCRIPTION_SECTION_NAME = 'Description';
 const CONTACTS_SECTION_NAME = 'Contacts';
 const TAGS_SECTION_NAME = 'Sections';
 const ENDPOINTS_SECTION_NAME = 'Endpoints';
@@ -22,7 +21,6 @@ const SPEC_SECTION_TYPE = 'Open API';
 export {
     TAG_NAMES_FIELD,
     BLOCK,
-    DESCRIPTION_SECTION_NAME,
     CONTACTS_SECTION_NAME,
     TAGS_SECTION_NAME,
     ENDPOINTS_SECTION_NAME,
@@ -45,7 +43,6 @@ export {
 export default {
     TAG_NAMES_FIELD,
     BLOCK,
-    DESCRIPTION_SECTION_NAME,
     CONTACTS_SECTION_NAME,
     TAGS_SECTION_NAME,
     ENDPOINTS_SECTION_NAME,

--- a/src/services/includers/batteries/openapi/generators/main.ts
+++ b/src/services/includers/batteries/openapi/generators/main.ts
@@ -4,7 +4,6 @@ import stringify from 'json-stringify-safe';
 
 import {page, block, title, body, mono, link, list, cut, code} from './common';
 import {
-    DESCRIPTION_SECTION_NAME,
     CONTACTS_SECTION_NAME,
     TAGS_SECTION_NAME,
     SPEC_RENDER_MODE_DEFAULT,
@@ -55,7 +54,7 @@ function contactSource(data: Contact) {
 }
 
 function description(text?: string) {
-    return text?.length && block([title(2)(DESCRIPTION_SECTION_NAME), body(text)]);
+    return text?.length && body(text);
 }
 
 function sections({tags, endpoints}: Specification) {

--- a/src/services/includers/batteries/openapi/generators/section.ts
+++ b/src/services/includers/batteries/openapi/generators/section.ts
@@ -1,6 +1,6 @@
 /* eslint-disable-next-line no-shadow */
 import {page, block, title, body, link, list} from './common';
-import {DESCRIPTION_SECTION_NAME, ENDPOINTS_SECTION_NAME} from '../constants';
+import {ENDPOINTS_SECTION_NAME} from '../constants';
 
 import {Tag, Endpoint, Endpoints} from '../types';
 
@@ -15,7 +15,7 @@ function section(tag: Tag) {
 }
 
 function description(text?: string) {
-    return text?.length && block([title(2)(DESCRIPTION_SECTION_NAME), body(text)]);
+    return text?.length && body(text);
 }
 
 function endpoints(data?: Endpoints) {


### PR DESCRIPTION
get rid of the Description title on the leading pages

for the reason it being redundant and a waste of vertical space