### PR TITLE
fix(includers/openapi): move disable lint directive

### DIFF
--- a/src/services/includers/batteries/openapi/generators/common.ts
+++ b/src/services/includers/batteries/openapi/generators/common.ts
@@ -58,7 +58,7 @@ function escapeTableColContent(cellContent: string) {
 }
 
 function page(content: string) {
-    return `${HTML_COMMENTS_OPEN_DIRECTIVE} ${DISABLE_LINTER_DIRECTIVE} ${HTML_COMMENTS_CLOSE_DIRECTIVE}\n${content}`;
+    return `${content}\n${HTML_COMMENTS_OPEN_DIRECTIVE} ${DISABLE_LINTER_DIRECTIVE} ${HTML_COMMENTS_CLOSE_DIRECTIVE}`;
 }
 
 export {list, link, title, body, mono, table, code, cut, block, page};


### PR DESCRIPTION
move directive that disabled linting for the generated content towards end of the file

prevents failure of page title parsing