### PR TITLE
fix(includers/openapi): response status text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6067,6 +6067,11 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
+    },
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
@@ -6756,7 +6761,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "json5": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "fast-xml-parser": "^4.0.11",
     "glob": "^8.0.3",
     "highlight.js": "^11.7.0",
+    "http-status-codes": "^2.2.0",
     "js-yaml": "4.1.0",
     "json-stringify-safe": "^5.0.1",
     "mime-types": "2.1.34",

--- a/src/services/includers/batteries/openapi/generators/endpoint.ts
+++ b/src/services/includers/batteries/openapi/generators/endpoint.ts
@@ -141,8 +141,14 @@ function responses(refs: Refs, visited: Set<string>, resps?: Responses) {
 }
 
 function response(allRefs: Refs, visited: Set<string>, resp: Response) {
+    let header = resp.code;
+
+    if (resp.statusText.length) {
+        header += ` ${resp.statusText}`;
+    }
+
     return block([
-        title(2)(resp.code),
+        title(2)(header),
         body(resp.description),
         resp.schemas?.length && block(resp.schemas.map((s) => openapiBody(allRefs, visited, s))),
     ]);

--- a/src/services/includers/batteries/openapi/parsers.ts
+++ b/src/services/includers/batteries/openapi/parsers.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-shadow */
 import slugify from 'slugify';
+import {getStatusText} from 'http-status-codes';
 
 import {TAG_NAMES_FIELD} from './constants';
 
@@ -124,7 +125,13 @@ function paths(spec: OpenapiSpec, tagsByID: Map<string, Tag>): Specification {
 
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
         const parseResponse = ([code, response]: [string, {[key: string]: any}]) => {
-            const parsed: Response = {code, description: response.description};
+            const parsed: Partial<Response> = {code, description: response.description};
+
+            try {
+                parsed.statusText = getStatusText(code);
+            } catch (err) {
+                parsed.statusText = '';
+            }
 
             if (response.content) {
                 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -132,7 +139,7 @@ function paths(spec: OpenapiSpec, tagsByID: Map<string, Tag>): Specification {
                     .map(([type, schema]) => ({type, schema: schema.schema}));
             }
 
-            return parsed;
+            return parsed as Response;
         };
 
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/src/services/includers/batteries/openapi/types.ts
+++ b/src/services/includers/batteries/openapi/types.ts
@@ -113,6 +113,7 @@ export type Responses = Response[];
 export type Response = {
     // response code validation omitted
     code: string;
+    statusText: string;
     description: string;
     schemas?: Schemas;
 };


### PR DESCRIPTION
render response status text on the endpoint page

![telegram-cloud-photo-size-2-5397817960657176285-x](https://user-images.githubusercontent.com/10233823/216734011-c2a37273-9e5e-4e93-bbf2-6c7589d30ed6.jpg)
![telegram-cloud-photo-size-2-5397817960657176286-y](https://user-images.githubusercontent.com/10233823/216734021-201f1128-d421-43b3-89b9-c79ee18f6373.jpg)