### PR TITLE
Fix link with allOf property

### DIFF
--- a/src/services/includers/batteries/openapi/generators/traverse.ts
+++ b/src/services/includers/batteries/openapi/generators/traverse.ts
@@ -228,7 +228,7 @@ function merge(value: OpenJSONSchemaDefinition): OpenJSONSchema {
             properties[k] = v;
         }
     }
-    return {type: 'object', description, properties};
+    return {type: 'object', description, properties, allOf: value.allOf};
 }
 
 function isRequired(key: string, value: JSONSchema6): boolean {


### PR DESCRIPTION
I corrected the references for such entities, because during the conversion, the allOf was lost, which determines the belonging to the model.

```
ScrollingPagerDTO:
  description: Информация о страницах результатов.
  type: object
  allOf:
    - $ref: '#/ForwardScrollingPagerDTO'
    - properties:
        prevPageToken:
          description: Идентификатор предыдущей страницы результатов.
          type: string
```


Before:
<img width="884" alt="Screenshot 2023-03-09 at 14 44 26" src="https://user-images.githubusercontent.com/112015178/224013456-85b792f7-b7a9-4156-8817-1beaa1d515c9.png">

After:
<img width="905" alt="Screenshot 2023-03-09 at 14 41 20" src="https://user-images.githubusercontent.com/112015178/224012787-e197481f-34a6-434c-a07a-e4c2673d4f9d.png">
