### PR TITLE
fix download link

### DIFF
--- a/src/services/includers/batteries/openapi/plugin/public/components/Response.tsx
+++ b/src/services/includers/batteries/openapi/plugin/public/components/Response.tsx
@@ -53,7 +53,7 @@ export const Response: React.FC<{
             file && fileUrl && <div>
                 <Text variant="subheader-2" as="div">{TextEnum.RESPONSE_FILE_LABEL}:</Text>
                 <Text variant="body-2" as="div">
-                    <a href={fileUrl} download={file.name}>
+                    <a href={fileUrl} download={file.name} data-router="off">
                         {file.name}
                     </a>
                 </Text>


### PR DESCRIPTION
handler for clicks on links in the viewer, external links are ignored and with the attribute data-router=off, the link to the blob is not external, therefore this attribute is needed