### PR TITLE
add default type "object"

### DIFF
--- a/src/services/includers/batteries/openapi/generators/traverse.ts
+++ b/src/services/includers/batteries/openapi/generators/traverse.ts
@@ -248,7 +248,7 @@ function inferType(value: OpenJSONSchema): Exclude<JSONSchema6['type'], undefine
         }
         throw new Error('Unsupported enum type');
     }
-    throw new Error('Unsupported value type');
+    return 'object';
 }
 
 function isSupportedEnumType(enumType: JsType): enumType is SupportedEnumType {


### PR DESCRIPTION
if the type is not specified and not enum, set the default value

before:
<img width="449" alt="Screenshot 2023-03-14 at 20 42 13" src="https://user-images.githubusercontent.com/112015178/225098494-91db6c93-42c1-4492-a54c-c78aa6af6d7a.png">

after:
<img width="472" alt="Screenshot 2023-03-14 at 21 10 14" src="https://user-images.githubusercontent.com/112015178/225098577-e312eb15-015c-442e-8aa6-72b6a7a209cd.png">


Sample value:
```
properties:
  code:
    default: 200
```
