### PR TITLE
includers: drop includer field support

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -86,35 +86,30 @@ export interface YfmTocInclude {
     repo: string;
     path: string;
     mode?: IncludeMode;
-    includer?: YfmTocIncluder;
     includers?: YfmTocIncluders;
 }
 
-export type YfmTocIncludersNormalized = YfmTocIncluderObject[];
-
 export type YfmTocIncluders = YfmTocIncluder[];
 
-export type YfmTocIncluder = YfmTocIncluderName | YfmTocIncluderObject;
-
-export const includersNames = ['sourcedocs', 'openapi', 'generic', 'unarchive'] as const;
-
-export type YfmTocIncluderName = typeof includersNames[number];
-
-export type YfmTocIncluderObject = {
+export type YfmTocIncluder = {
     name: YfmTocIncluderName;
     // arbitrary includer parameters
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } & Record<string, unknown>;
 
-export type Includer = {
-    name: YfmTocIncluderName;
-    includerFunction: IncluderFunction;
-};
+export const includersNames = ['sourcedocs', 'openapi', 'generic', 'unarchive'] as const;
+
+export type YfmTocIncluderName = typeof includersNames[number];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type IncluderFunction = (args: IncluderFunctionParams) => Promise<any>;
+export type Includer<FnParams = any> = {
+    name: YfmTocIncluderName;
+    includerFunction: IncluderFunction<FnParams>;
+};
 
-export type IncluderFunctionParams<Params extends Record<string, unknown> = Record<string, unknown>> = {
+export type IncluderFunction<PassedParams> = (args: IncluderFunctionParams<PassedParams>) => Promise<void>;
+
+export type IncluderFunctionParams<PassedParams> = {
     // item that contains include that uses includer
     item: YfmToc;
     // base read directory path
@@ -125,8 +120,7 @@ export type IncluderFunctionParams<Params extends Record<string, unknown> = Reco
     tocPath: string;
     vars: YfmPreset;
     // arbitrary includer parameters
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    passedParams: Params;
+    passedParams: PassedParams;
     index: number;
 };
 

--- a/src/services/includers/batteries/unarchive.ts
+++ b/src/services/includers/batteries/unarchive.ts
@@ -90,8 +90,6 @@ async function includerFunction(params: IncluderFunctionParams<Params>) {
     } catch (err) {
         throw new UnarchiveIncluderError(err.toString(), tocPath);
     }
-
-    return {input: output};
 }
 
 export {name, includerFunction};


### PR DESCRIPTION
includers are now to be specified as array using the full syntax
(even when using only one includer):

```
include:
  path: <path-where-to-include>
  includers:
    - name: <includer-name-0>
      <includer-parameter>: <value-for-includer-parameter>
    - name: <includer-name-1>
      <includer-parameter>: <value-for-includer-parameter>
```

BREAKING CHANGE: drop support for `includer` field inside include
                 drop support for specifying `includer` as name string