### PR TITLE
cmd/xliff: @diplodoc/markdown-translation integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1557,6 +1557,11 @@
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.2.tgz",
       "integrity": "sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg=="
     },
+    "@cospired/i18n-iso-languages": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@cospired/i18n-iso-languages/-/i18n-iso-languages-4.1.0.tgz",
+      "integrity": "sha512-5+JK7YiO9r/FmwtlEPL1tQNt04/9AuN1t9GO/0C2yitqhKwFRa1r7VohNNUnFgB84MW5v4Lwq8ZAUZexuJh1nQ=="
+    },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -1574,6 +1579,51 @@
           "requires": {
             "@jridgewell/resolve-uri": "^3.0.3",
             "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
+    },
+    "@diplodoc/markdown-it-custom-renderer": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-it-custom-renderer/-/markdown-it-custom-renderer-0.0.2.tgz",
+      "integrity": "sha512-PzjcMaqgRrqkBKUfF8A1abThOtQ+c1o5ma4d9bnrsfgmWtlScrr9O1VgBV5aeDPhm3LfhbdQSTDask9AS41rBA=="
+    },
+    "@diplodoc/markdown-it-markdown-renderer": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-it-markdown-renderer/-/markdown-it-markdown-renderer-0.0.3.tgz",
+      "integrity": "sha512-rgl10zMwZ8a/EQWACeC119+hiQW0OVFnE/I9gh9FYUvPHdnz7hRSt21mUa2UziMcD+r2yt2Ujsfbs2TBVwHzoA==",
+      "requires": {
+        "@diplodoc/markdown-it-custom-renderer": "0.0.1"
+      },
+      "dependencies": {
+        "@diplodoc/markdown-it-custom-renderer": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/@diplodoc/markdown-it-custom-renderer/-/markdown-it-custom-renderer-0.0.1.tgz",
+          "integrity": "sha512-CuCzY7k56FsjBl9HWAesDRcLfIm5tPlPH6Mgjh0u8SJpthvE+psx5FxWu1Czu/KqfV/bxdeOFmRZ7CChw4qbUg=="
+        }
+      }
+    },
+    "@diplodoc/markdown-translation": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-translation/-/markdown-translation-0.0.2.tgz",
+      "integrity": "sha512-VXcPHyZ7DSUwOdYlqSp+YKG99TNxnpzmPnEzSny7l7p5eC7LhZ4Rhyf8KssiyGL61fpYHzKdCIGfcnE6UM2Axw==",
+      "requires": {
+        "@cospired/i18n-iso-languages": "^4.1.0",
+        "@diplodoc/markdown-it-custom-renderer": "0.0.2",
+        "@diplodoc/markdown-it-markdown-renderer": "0.0.3",
+        "@diplodoc/sentenizer": "0.0.0",
+        "fast-xml-parser": "^4.1.3",
+        "i18n-iso-countries": "^7.5.0",
+        "js-yaml": "^4.1.0",
+        "markdown-it-meta": "0.0.1"
+      },
+      "dependencies": {
+        "fast-xml-parser": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.2.tgz",
+          "integrity": "sha512-DLzIPtQqmvmdq3VUKR7T6omPK/VCRNqgFlGtbESfyhcH2R4I8EzK1/K6E8PkRCK2EabWrUHK32NjYRbEFnnz0Q==",
+          "requires": {
+            "strnum": "^1.0.5"
           }
         }
       }
@@ -1597,6 +1647,15 @@
             "loose-envify": "^1.1.0"
           }
         }
+      }
+    },
+    "@diplodoc/sentenizer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@diplodoc/sentenizer/-/sentenizer-0.0.0.tgz",
+      "integrity": "sha512-t0h0XJzWgIBNExVTkpCEYjRkunCH1zlE9Wwh+BX4nglRa9LCp93btYBNmSvNWKOUhledNC5z3b305yo9HNRdFQ==",
+      "requires": {
+        "@types/ramda": "^0.28.13",
+        "ramda": "^0.28.0"
       }
     },
     "@doc-tools/components": {
@@ -4858,6 +4917,11 @@
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
+    "diacritics": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
+      "integrity": "sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA=="
+    },
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -6771,6 +6835,14 @@
             "find-up": "^5.0.0"
           }
         }
+      }
+    },
+    "i18n-iso-countries": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/i18n-iso-countries/-/i18n-iso-countries-7.6.0.tgz",
+      "integrity": "sha512-HPKjOUKS0BkjiY4ayrsuFbu7Ock++pXLs+FAOYl4WfTL5L0ploEH68fiRAP6Zev5g/jvMFt54KcPGJcb942wbg==",
+      "requires": {
+        "diacritics": "1.3.0"
       }
     },
     "i18next": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
+    "@diplodoc/markdown-translation": "0.0.2",
     "@diplodoc/mermaid-extension": "0.0.2",
     "@doc-tools/components": "^2.7.2",
     "@doc-tools/transform": "^3.0.0",

--- a/src/cmd/xliff/compose.ts
+++ b/src/cmd/xliff/compose.ts
@@ -1,34 +1,22 @@
-import {Arguments} from 'yargs';
 const {promises: {readFile, writeFile, mkdir}} = require('fs');
-import {join, resolve, dirname} from 'path';
+import {join, extname, dirname} from 'path';
 
-const yfm2xliff = require('@doc-tools/yfm2xliff/lib/cjs');
+import markdownTranslation, {ComposeParameters} from '@diplodoc/markdown-translation';
+import {Arguments, Argv} from 'yargs';
+import {eachLimit} from 'async';
 
 import {ArgvService} from '../../services';
 import {glob, logger} from '../../utils';
-import {MD_EXT_NAME, SKL_EXT_NAME, XLF_EXT_NAME} from './constants';
 
 const command = 'compose';
 
 const description = 'compose xliff and skeleton into documentation';
 
-const compose = {command, description, handler};
+const compose = {command, description, handler, builder};
 
-const XLFExtPattern = `\\.${XLF_EXT_NAME}$`;
-const XLFExtFlags = 'mui';
-const XLFExtRegExp = new RegExp(XLFExtPattern, XLFExtFlags);
-
-const SKL_MD_GLOB = `**/*.${SKL_EXT_NAME}.${MD_EXT_NAME}`;
-const XLF_GLOB = `**/*.${XLF_EXT_NAME}`;
-
-const composer = async (xliff: string, skeleton: string) => new Promise((res, rej) =>
-    yfm2xliff.compose(xliff, skeleton, (err: Error, composed: string) => {
-        if (err) {
-            rej(err);
-        }
-
-        return res(composed);
-    }));
+const SKL_MD_GLOB = '**/*.skl.md';
+const XLF_GLOB = '**/*.xliff';
+const MAX_CONCURRENCY = 50;
 
 class ComposeError extends Error {
     path: string;
@@ -40,6 +28,23 @@ class ComposeError extends Error {
     }
 }
 
+const USAGE = 'yfm xliff compose \
+--input <folder-with-xliff-and-skeleton> \
+--ouput <folder-to-store-translated-markdown>';
+
+function builder<T>(argv: Argv<T>) {
+    return argv
+        .option('input', {
+            alias: 'i',
+            describe: 'input folder with xliff and skeleton files',
+            type: 'string',
+        }).option('output', {
+            alias: 'o',
+            describe: 'output folder where translated markdown will be stored',
+            type: 'string',
+        }).demandOption(['input', 'output'], USAGE);
+}
+
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 async function handler(args: Arguments<any>) {
     ArgvService.init({
@@ -48,105 +53,167 @@ async function handler(args: Arguments<any>) {
 
     const {input, output} = args;
 
-    logger.info(input, 'composing skeleton and xliff files');
+    let cache = {};
+    let skeletonPaths: string[] = [];
+    let xliffPaths: string[] = [];
 
     try {
-        let cache = {};
-        let found = [];
-
-        ({state: {found, cache}} = await glob(join(input, SKL_MD_GLOB), {
+        ({state: {found: skeletonPaths, cache}} = await glob(join(input, SKL_MD_GLOB), {
             nosort: false,
             cache,
         }));
 
-        const sklPaths = found;
-
-        ({state: {found, cache}} = await glob(join(input, XLF_GLOB), {
+        ({state: {found: xliffPaths, cache}} = await glob(join(input, XLF_GLOB), {
             nosort: false,
             cache,
         }));
 
-        const xlfPaths = found;
-
-        if (!xlfPaths?.length || xlfPaths?.length !== sklPaths?.length) {
-            throw new ComposeError('failed reading skeleton and xliff files', input);
+        if (xliffPaths.length !== skeletonPaths.length) {
+            throw new ComposeError('number of xliff and skeleton files does\'not match', input);
         }
-
-        logger.info(input, 'reading skeleton and xliff files');
-
-        const [skls, xlfs, paths] = await Promise.all([
-            Promise.all(sklPaths.map(readFn)),
-            Promise.all(xlfPaths.map(readFn)),
-            Promise.all(xlfPaths.map(async (path: string) =>
-                path.replace(XLFExtRegExp, '').replace(input, output)))]);
-
-        logger.info(input, 'finished reading skeleton and xliff files');
-
-        const composed = await Promise.all(paths.map(composeFn(xlfs, skls)));
-
-        await Promise.all(composed.map(writeFn));
-
-        logger.info(output, 'finished composing into documentation');
     } catch (err) {
         if (err instanceof Error || err instanceof ComposeError) {
-            const message = err.message;
+            const file = err instanceof ComposeError ? err.path : input;
 
-            const file = err instanceof ComposeError ? err.path : '';
-
-            logger.error(file, message);
+            logger.error(file, err.message);
         }
     }
-}
 
-async function readFn(path: string) {
-    logger.info(path, 'reading file');
-
-    let file;
+    const pipelineParameters = {input, output};
+    const configuredPipeline = pipeline(pipelineParameters);
 
     try {
-        file = readFile(resolve(path), {encoding: 'utf-8'});
-    } catch (err) {
-        throw new ComposeError(err.message, path);
-    }
+        logger.info(input, 'staring translated markdown composition pipeline');
 
-    return file;
+        await eachLimit(xliffPaths, MAX_CONCURRENCY, configuredPipeline);
+
+        logger.info(input, 'finished translated markdown composition pipeline');
+    } catch (err) {
+        if (err instanceof Error || err instanceof ComposeError) {
+            const file = err instanceof ComposeError ? err.path : input;
+
+            logger.error(file, err.message);
+        }
+    }
 }
 
-export type ComposeFnOutput = {
-    path: string;
-    composed: string;
+export type PipelineParameters = {
+    input: string;
+    output: string;
 };
 
-function composeFn(xlfs: string[], skls: string[]) {
-    return async (path: string, i: number): Promise<ComposeFnOutput> => {
-        logger.info(path, 'composing skeleton and xliff files');
+function pipeline(params: PipelineParameters) {
+    const {input, output} = params;
 
-        let composed;
+    return async (xliffPath: string) => {
+        const extension = extname(xliffPath);
+        const extensionLessPath = xliffPath.replace(extension, '');
+        const skeletonPath = extensionLessPath + '.skl.md';
 
-        try {
-            composed = await composer(xlfs[i], skls[i]) as string;
-        } catch (err) {
-            throw new ComposeError(err.message, path);
-        }
+        const readerParameters = {xliffPath, skeletonPath};
+        const read = await reader(readerParameters);
 
-        return {
-            composed,
-            path,
+        const composerParameters = {
+            ...read,
+            skeletonPath,
+            xliffPath,
         };
+        const {markdown} = await composer(composerParameters);
+
+        const inputRelativePath = extensionLessPath.slice(input.length);
+        const markdownPath = join(output, inputRelativePath) + '.md';
+
+        const writerParameters = {
+            markdown,
+            markdownPath,
+        };
+        await writer(writerParameters);
     };
 }
 
-async function writeFn({composed, path}: ComposeFnOutput) {
-    const file = `${path}.md`;
+export type ReaderParameters = {
+    skeletonPath: string;
+    xliffPath: string;
+};
 
-    logger.info(file, 'writing composed file');
+async function reader(params: ReaderParameters) {
+    const {skeletonPath, xliffPath} = params;
+
+    let skeleton;
+    let xlf;
 
     try {
-        await mkdir(dirname(path), {recursive: true});
+        logger.info(skeletonPath, 'reading skeleton file');
 
-        return writeFile(file, composed);
+        skeleton = await readFile(skeletonPath, {encoding: 'utf-8'});
+
+        logger.info(skeletonPath, 'finished reading skeleton file');
     } catch (err) {
-        throw new ComposeError(err.message, file);
+        if (err instanceof Error) {
+            throw new ComposeError(err.message, skeletonPath);
+        }
+    }
+
+    try {
+        logger.info(xliffPath, 'reading xliff file');
+
+        xlf = await readFile(xliffPath, {encoding: 'utf-8'});
+
+        logger.info(xliffPath, 'finished reading xliff file');
+    } catch (err) {
+        if (err instanceof Error) {
+            throw new ComposeError(err.message, xliffPath);
+        }
+    }
+
+    return {skeleton, xlf};
+}
+
+export type ComposerParameters = {
+    skeletonPath: string;
+    xliffPath: string;
+} & ComposeParameters;
+
+async function composer(params: ComposerParameters) {
+    const {skeletonPath, xliffPath} = params;
+    let markdown;
+
+    try {
+        logger.info(skeletonPath, 'composing markdown from xliff and skeleton');
+        logger.info(xliffPath, 'composing markdown from xliff and skeleton');
+
+        markdown = markdownTranslation.compose(params);
+
+        logger.info(skeletonPath, 'finished composing markdown from xliff and skeleton');
+        logger.info(xliffPath, 'finished composing markdown from xliff and skeleton');
+    } catch (err) {
+        if (err instanceof Error) {
+            throw new ComposeError(err.message, `${xliffPath} ${skeletonPath}`);
+        }
+    }
+
+    return {markdown};
+}
+
+export type WriterParameters = {
+    markdown: string;
+    markdownPath: string;
+};
+
+async function writer(params: WriterParameters) {
+    const {markdown, markdownPath} = params;
+
+    try {
+        logger.info(markdownPath, 'writing markdown file');
+
+        await mkdir(dirname(markdownPath), {recursive: true});
+        await writeFile(markdownPath, markdown);
+
+        logger.info(markdownPath, 'finished writing markdown file');
+    } catch (err) {
+        if (err instanceof Error) {
+            throw new ComposeError(err.message, markdownPath);
+        }
     }
 }
 

--- a/src/cmd/xliff/constants.ts
+++ b/src/cmd/xliff/constants.ts
@@ -1,7 +1,0 @@
-const MD_EXT_NAME = 'md';
-const SKL_EXT_NAME = 'skl';
-const XLF_EXT_NAME = 'xlf';
-
-export {MD_EXT_NAME, SKL_EXT_NAME, XLF_EXT_NAME};
-
-export default {MD_EXT_NAME, SKL_EXT_NAME, XLF_EXT_NAME};


### PR DESCRIPTION
[feat(cmd/xliff): extract xliff and skeleton](https://github.com/yandex-cloud/yfm-docs/commit/603d99075fd1e70c0ae649ea523843d9fa61921b) 

@diplodoc/markdown-translation integration to extract xliff and skeleton

[feat(cmd/xliff): compose xliff and skeleton into markdown](https://github.com/yandex-cloud/yfm-docs/commit/f9a4115f36da97f5f07cba8164749417c86a9738) 

@diplodoc/markdown-translation integration to compose xliff and
skeleton files into translated markdown