### PR TITLE
infra: dependabot.yml reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,5 @@ updates:
     schedule:
       interval: "daily"
     reviewers:
-      - "diplodoc-platform/contributors"
+      - "yandex-cloud/yfm"
     open-pull-requests-limit: 5


### PR DESCRIPTION
use appropriate group as reviewers