### PR TITLE
feat(cmd/xliff): @diplodoc/anchors syntax support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -337,9 +337,9 @@
       "integrity": "sha512-PzjcMaqgRrqkBKUfF8A1abThOtQ+c1o5ma4d9bnrsfgmWtlScrr9O1VgBV5aeDPhm3LfhbdQSTDask9AS41rBA=="
     },
     "@diplodoc/markdown-it-markdown-renderer": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-it-markdown-renderer/-/markdown-it-markdown-renderer-0.6.0.tgz",
-      "integrity": "sha512-8MN+rzno6FSuL0+w5lb4dvdNtbSA/jrTxHHQytl9TskrJiPaTMyk7ChTfpVAoiNoMlmK+XZwxMx9Lp6hXpmlBw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-it-markdown-renderer/-/markdown-it-markdown-renderer-0.7.1.tgz",
+      "integrity": "sha512-5p9Acdgvwp7s8waZx19RdVRDqqU21z/WpYYnzy1VP9ss9tIjp6vM4MbSMy7NnMxIUQRbCWLSWRIu0dgBQyOWVw==",
       "requires": {
         "@diplodoc/markdown-it-custom-renderer": "0.0.1",
         "@doc-tools/transform": "^3.1.1",
@@ -350,44 +350,17 @@
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/@diplodoc/markdown-it-custom-renderer/-/markdown-it-custom-renderer-0.0.1.tgz",
           "integrity": "sha512-CuCzY7k56FsjBl9HWAesDRcLfIm5tPlPH6Mgjh0u8SJpthvE+psx5FxWu1Czu/KqfV/bxdeOFmRZ7CChw4qbUg=="
-        },
-        "@doc-tools/transform": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/@doc-tools/transform/-/transform-3.1.1.tgz",
-          "integrity": "sha512-sLmY9swL+Ab0Fcl5cy73f6gcqi5Xpz+6nbughntKYZlHPp6YHDgaNwaMR6dKXySuxRNRQQsecBnyLnC0IMIIGg==",
-          "requires": {
-            "chalk": "4.1.2",
-            "get-root-node-polyfill": "1.0.0",
-            "github-slugger": "1.4.0",
-            "js-yaml": "^4.1.0",
-            "lodash": "4.17.21",
-            "markdown-it": "13.0.1",
-            "markdown-it-attrs": "4.1.4",
-            "markdown-it-deflist": "2.1.0",
-            "markdown-it-meta": "0.0.1",
-            "markdown-it-sup": "1.0.0",
-            "markdownlint": "^0.25.1",
-            "markdownlint-rule-helpers": "0.17.2",
-            "postcss": "8.4.16",
-            "sanitize-html": "2.7.3",
-            "slugify": "1.6.5"
-          }
-        },
-        "slugify": {
-          "version": "1.6.5",
-          "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
-          "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ=="
         }
       }
     },
     "@diplodoc/markdown-translation": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-translation/-/markdown-translation-0.5.0.tgz",
-      "integrity": "sha512-QXwfa9Rc8zXoJ91iop7p9bRa7WuHRbduQSk/7AipheNcTbJnfUsgwz8hflzh6R2cIXIUSarHn7es+Kn5nCKruA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-translation/-/markdown-translation-0.6.0.tgz",
+      "integrity": "sha512-ml3uEr6fdmPw6uJ/wOK1kndJujK945X7RpXC/T3CQsd3LAmV6s/1rAPvK0E8pAlFfuLkDxHK64mls9xL7fppIg==",
       "requires": {
         "@cospired/i18n-iso-languages": "^4.1.0",
         "@diplodoc/markdown-it-custom-renderer": "0.0.2",
-        "@diplodoc/markdown-it-markdown-renderer": "^0.6.0",
+        "@diplodoc/markdown-it-markdown-renderer": "^0.7.1",
         "@diplodoc/sentenizer": "0.0.0",
         "@doc-tools/transform": "^3.1.1",
         "@shellscape/i18n-iso-countries": "^7.5.0-shellscape.v1",
@@ -395,35 +368,6 @@
         "js-yaml": "^4.1.0",
         "markdown-it-meta": "0.0.1",
         "markdown-it-sup": "^1.0.0"
-      },
-      "dependencies": {
-        "@doc-tools/transform": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/@doc-tools/transform/-/transform-3.1.1.tgz",
-          "integrity": "sha512-sLmY9swL+Ab0Fcl5cy73f6gcqi5Xpz+6nbughntKYZlHPp6YHDgaNwaMR6dKXySuxRNRQQsecBnyLnC0IMIIGg==",
-          "requires": {
-            "chalk": "4.1.2",
-            "get-root-node-polyfill": "1.0.0",
-            "github-slugger": "1.4.0",
-            "js-yaml": "^4.1.0",
-            "lodash": "4.17.21",
-            "markdown-it": "13.0.1",
-            "markdown-it-attrs": "4.1.4",
-            "markdown-it-deflist": "2.1.0",
-            "markdown-it-meta": "0.0.1",
-            "markdown-it-sup": "1.0.0",
-            "markdownlint": "^0.25.1",
-            "markdownlint-rule-helpers": "0.17.2",
-            "postcss": "8.4.16",
-            "sanitize-html": "2.7.3",
-            "slugify": "1.6.5"
-          }
-        },
-        "slugify": {
-          "version": "1.6.5",
-          "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
-          "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ=="
-        }
       }
     },
     "@diplodoc/mermaid-extension": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
     "@diplodoc/client": "0.0.6",
-    "@diplodoc/markdown-translation": "^0.5.0",
+    "@diplodoc/markdown-translation": "^0.6.0",
     "@diplodoc/mermaid-extension": "0.0.2",
     "@diplodoc/openapi-extension": "^1.2.5",
     "@doc-tools/transform": "^3.0.2",


### PR DESCRIPTION
update to latest markdown-translation version, that supports anchors