### PR TITLE
feat(cmd/xliff): @diplodoc/file support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -337,9 +337,9 @@
       "integrity": "sha512-PzjcMaqgRrqkBKUfF8A1abThOtQ+c1o5ma4d9bnrsfgmWtlScrr9O1VgBV5aeDPhm3LfhbdQSTDask9AS41rBA=="
     },
     "@diplodoc/markdown-it-markdown-renderer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-it-markdown-renderer/-/markdown-it-markdown-renderer-0.8.0.tgz",
-      "integrity": "sha512-GNOP+fzMvdJDx+klc3H2Ii5jDsS2Q1sA3uHGi0uqypIR2SHLqjilNPL9RIKlP/Pl0BOicfT+4LqOOVGHRozUxA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-it-markdown-renderer/-/markdown-it-markdown-renderer-0.9.0.tgz",
+      "integrity": "sha512-Ml17mstRbFGDypQxlzrwdNijhGwZfC3/tMIXjs1CaaFvj379GuhMRbBtZxUsSK9GfgePJQfxITF3x8cvmMt+mQ==",
       "requires": {
         "@diplodoc/markdown-it-custom-renderer": "0.0.1",
         "@doc-tools/transform": "^3.1.1",
@@ -354,13 +354,13 @@
       }
     },
     "@diplodoc/markdown-translation": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-translation/-/markdown-translation-0.8.0.tgz",
-      "integrity": "sha512-Hv59XGwcrFSkY+4ZlD6YfuRK1zeC96OXuq+UMqnraqDNjmwIZlcWh3gZvvywM4cYBOiXfl9ro+nxgcUhoJoJ0g==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-translation/-/markdown-translation-0.9.0.tgz",
+      "integrity": "sha512-P3+Bt4L5OFGjja8vafxCws7a2AhN6fc8SzDxOtGOMqdP+w8Udn476CU8FkV7bPZGhFhxCEjnOTL8UcURugdL2A==",
       "requires": {
         "@cospired/i18n-iso-languages": "^4.1.0",
         "@diplodoc/markdown-it-custom-renderer": "0.0.2",
-        "@diplodoc/markdown-it-markdown-renderer": "^0.8.0",
+        "@diplodoc/markdown-it-markdown-renderer": "^0.9.0",
         "@diplodoc/sentenizer": "0.0.0",
         "@doc-tools/transform": "^3.1.1",
         "@shellscape/i18n-iso-countries": "^7.5.0-shellscape.v1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
     "@diplodoc/client": "0.0.6",
-    "@diplodoc/markdown-translation": "^0.8.0",
+    "@diplodoc/markdown-translation": "^0.9.0",
     "@diplodoc/mermaid-extension": "0.0.2",
     "@diplodoc/openapi-extension": "^1.2.5",
     "@doc-tools/transform": "^3.1.2",


### PR DESCRIPTION
update markdown-translation up to the version that supports @diplodoc/file syntax