### PR TITLE
fix: bump openapi version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -381,9 +381,9 @@
       }
     },
     "@diplodoc/openapi-extension": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@diplodoc/openapi-extension/-/openapi-extension-1.2.5.tgz",
-      "integrity": "sha512-9WJcX4HzAGLm039CgS1lox/FPiEQhDAkEhUKZZ4QU+HTcse3MLwWqO+nbr6hDk/g1FiwuOil9kciUQ52DR4RRA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@diplodoc/openapi-extension/-/openapi-extension-1.2.6.tgz",
+      "integrity": "sha512-4ABatUOmQeJGQSp3JfS6DcVkAsUO/161Em7lOT7CT8BP+4Ke5EPZGWRCpZbYp2edfdDzq5D24H1wuQ7Gis2Zrw==",
       "requires": {
         "@apidevtools/swagger-parser": "^10.1.0",
         "html-escaper": "^3.0.3",
@@ -2692,7 +2692,7 @@
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw=="
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "execa": {
       "version": "7.1.1",
@@ -3306,7 +3306,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -4564,7 +4564,7 @@
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "scheduler": {
       "version": "0.23.0",
@@ -5135,7 +5135,7 @@
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@diplodoc/client": "0.0.6",
     "@diplodoc/markdown-translation": "^0.10.0",
     "@diplodoc/mermaid-extension": "0.0.5",
-    "@diplodoc/openapi-extension": "^1.2.5",
+    "@diplodoc/openapi-extension": "^1.2.6",
     "@doc-tools/transform": "^3.1.2",
     "@doc-tools/yfm2xliff": "0.0.5",
     "@octokit/core": "4.2.4",


### PR DESCRIPTION
## Changelog:

Bumped OpenAPI extension plugin to [v1.2.6](https://github.com/diplodoc-platform/openapi-extension/releases/tag/v1.2.6)