### PR TITLE
feat(cmd/xliff): diplodoc includes, strikethrough

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -337,9 +337,9 @@
       "integrity": "sha512-PzjcMaqgRrqkBKUfF8A1abThOtQ+c1o5ma4d9bnrsfgmWtlScrr9O1VgBV5aeDPhm3LfhbdQSTDask9AS41rBA=="
     },
     "@diplodoc/markdown-it-markdown-renderer": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-it-markdown-renderer/-/markdown-it-markdown-renderer-0.9.0.tgz",
-      "integrity": "sha512-Ml17mstRbFGDypQxlzrwdNijhGwZfC3/tMIXjs1CaaFvj379GuhMRbBtZxUsSK9GfgePJQfxITF3x8cvmMt+mQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-it-markdown-renderer/-/markdown-it-markdown-renderer-0.10.0.tgz",
+      "integrity": "sha512-kZeeURQ/2eGKagiejYh7dEEdHUJ34ExnbVeJn7vEgzvyKpkR9XPlw0v9qDYYEorYyOfdycl3CWUtdsxwGUmIGw==",
       "requires": {
         "@diplodoc/markdown-it-custom-renderer": "0.0.1",
         "@doc-tools/transform": "^3.1.1",
@@ -354,13 +354,13 @@
       }
     },
     "@diplodoc/markdown-translation": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-translation/-/markdown-translation-0.10.0.tgz",
-      "integrity": "sha512-o3L2tP73/saYiG2xUDI9774yEWGdERAY7wfQoEpRA/lMqa0l38RxrOVnQRNuvMlekzfu/LZPXEVw05OX9Mjejg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@diplodoc/markdown-translation/-/markdown-translation-0.12.0.tgz",
+      "integrity": "sha512-OnDV9Mvnm3NmZv/j8T2kHgmOxc4PXa5UUconUVJ9l6alzsyYzCvVaDJ3ONvR/H8TjPtNaVoAraaR3kaKPAI4SA==",
       "requires": {
         "@cospired/i18n-iso-languages": "^4.1.0",
         "@diplodoc/markdown-it-custom-renderer": "0.0.2",
-        "@diplodoc/markdown-it-markdown-renderer": "^0.9.0",
+        "@diplodoc/markdown-it-markdown-renderer": "^0.10.0",
         "@diplodoc/sentenizer": "0.0.0",
         "@doc-tools/transform": "^3.1.1",
         "@shellscape/i18n-iso-countries": "^7.5.0-shellscape.v1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
     "@diplodoc/client": "0.0.6",
-    "@diplodoc/markdown-translation": "^0.10.0",
+    "@diplodoc/markdown-translation": "^0.12.0",
     "@diplodoc/mermaid-extension": "0.0.5",
     "@diplodoc/openapi-extension": "^1.2.6",
     "@doc-tools/transform": "^3.1.2",


### PR DESCRIPTION
update markdown-translation up to the latest version, that supports @diplodoc/includes syntax and strikethrough