### PR TITLE
fix: prop symbol case

### DIFF
--- a/src/core/vars/utils.ts
+++ b/src/core/vars/utils.ts
@@ -46,7 +46,7 @@ export function proxy<T extends object>(path: RelativePath, resolve: Resolver, p
 
                 const {value, scope, track, missed} = resolve(prop);
 
-                if (value === undefined) {
+                if (value === undefined && typeof prop !== 'symbol') {
                     missed(path, full(prefix, prop));
                     return undefined;
                 }


### PR DESCRIPTION
#### TypeError: Cannot convert a Symbol value to a string


