### PR TITLE
chore: mark all `name` props as required for `toc` schema

### DIFF
--- a/schemas/toc-schema.yaml
+++ b/schemas/toc-schema.yaml
@@ -57,6 +57,7 @@ definitions:
 
   TocItem:
     type: object
+    required: ['name']
     properties:
       name:
         type: string
@@ -85,7 +86,7 @@ definitions:
         type: string
 
   TocItemWithInclude:
-    required: ['include']
+    required: ['include', 'name']
     properties:
       name:
         type: string
@@ -138,6 +139,7 @@ definitions:
             format: url
       leadingPage:
         type: object
+        required: ['name']
         properties:
           name:
             type: string


### PR DESCRIPTION
relates #1400