### PR TITLE
Deterministic file order (in the TOC) for Generic Includer

### DIFF
--- a/src/extensions/generic-includer/index.ts
+++ b/src/extensions/generic-includer/index.ts
@@ -8,7 +8,7 @@ import type {
     YfmString,
 } from '@diplodoc/cli/lib/toc';
 
-import {dirname, extname, join} from 'node:path';
+import {dirname, extname, join, sep} from 'node:path';
 
 import {getHooks as getBaseHooks} from '@diplodoc/cli/lib/program';
 import {getHooks as getTocHooks} from '@diplodoc/cli/lib/toc';
@@ -41,8 +41,32 @@ export class Extension implements IExtension {
                         cwd: join(run.input, input),
                     });
 
-                    return fillToc(toc, graph(files), options);
+                    return fillToc(toc, graph(this.sortGlobResult(files)), options);
                 });
+        });
+    }
+
+    sortGlobResult(files: NormalizedPath[]): NormalizedPath[] {
+        return files.sort((a, b) => {
+            // index.md should be the first
+            if (b === 'index.md') {
+                return 1;
+            }
+
+            // First compare by number of segments
+            const segmentsA = a.split(sep).length;
+            const segmentsB = b.split(sep).length;
+
+            if (segmentsA !== segmentsB) {
+                return segmentsA - segmentsB;
+            }
+
+            // If same depth, sort alphabetically
+            if (a === b) {
+                return 0;
+            }
+
+            return a > b ? 1 : -1;
         });
     }
 }


### PR DESCRIPTION
## Description

Fix random order in the TOC, when using Generic Includer (doc readers may be confused).

Sort from the shortest paths to longest (by path segments).

Put `index.md` as the first item in the TOC (it seems to be useful for the most of use cases).