### PR TITLE
fix(template): preserve whitespace in body interpolation in Template.dump

### DIFF
--- a/src/core/template/template.ts
+++ b/src/core/template/template.ts
@@ -339,6 +339,11 @@ export class Template {
         const base = getDepthPath(getDepth(this.path) - 1);
         const faviconType = getFaviconType(faviconSrc);
 
+        // ts-dedent re-indents every line of a multi-line interpolation,
+        // which corrupts whitespace-significant content (e.g. <pre><code> blocks) inside body
+        // insert body via a placeholder so its newlines stay untouched
+        const BODY = '\x00BODY\x00';
+
         return dedent`
             <!DOCTYPE html>
             <html lang="${lang}" dir="${this.isRTL ? 'rtl' : 'ltr'}">
@@ -357,13 +362,13 @@ export class Template {
                     ${leading(styles).map(style(this.csp)).join('\n')}
                 </head>
                 <body class="${bodyClass.join(' ')}">
-                    ${body.join('\n') || `<div id="root"></div>`}
+                    ${BODY}
                     ${state(scripts).map(script(this.csp)).join('\n')}
                     ${trailing(scripts).map(script(this.csp)).join('\n')}
                     ${trailing(styles).map(style(this.csp)).join('\n')}
                 </body>
             </html>
-        `;
+        `.replace(BODY, body.join('\n') || `<div id="root"></div>`);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #1893.

`Template.dump()` (introduced in `5.0.0-rc-8`) builds the final page using a `ts-dedent` template literal. `ts-dedent` strips the common leading indent from the literal but **also re-indents every line of a multi-line interpolation** to the column of the `${...}` placeholder.

`body.join('\n')` is interpolated 8 spaces deep inside `<body>`, so every line **after the first** of the SSR-rendered body markup gets 8 extra spaces prepended. For most tags this is invisible, but inside whitespace-significant content like `<pre><code>` blocks the extra indent shows up verbatim in the rendered page:

```html
<!-- before -->
<pre><code class="hljs bash">./first-line.sh
        ./second-line.sh        <!-- 8 extra spaces -->
        ./third-line.sh         <!-- 8 extra spaces -->
</code></pre>
```

## Fix

Insert `body.join('\n')` via a placeholder (`\x00BODY\x00`) and substitute it with `.replace()` **after** `dedent` has finished processing, so the body's newlines stay untouched. Body is the only whitespace-significant interpolation in the template, so other interpolations don't need protection.

## Reproduction

Standalone `ts-dedent` repro (10 lines), regression range `5.0.0-rc-4` (clean) → `5.0.0-rc-8` (broken), and full evidence are in the linked issue (#1893).

## Verification

Built `lib/template` from the patched source, dropped it into `node_modules/@diplodoc/cli/lib/template/` of a real docs project, and ran a full `npx @diplodoc/cli` build. Generated `<pre><code>` blocks now contain content with 0 leading spaces — matching the `4.x` behaviour.

Closes #1893
