### PR TITLE
feat(generic-includer): add opt-in natural sort options

### DIFF
--- a/src/extensions/generic-includer/__snapshots__/index.spec.ts.snap
+++ b/src/extensions/generic-includer/__snapshots__/index.spec.ts.snap
@@ -1,5 +1,95 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Generic includer > should preserve insertion order without orderBy 1`] = `
+"path: toc.yaml
+items:
+  - name: banana
+    href: banana.md
+  - name: apple
+    href: apple.md
+  - name: cherry
+    href: cherry.md
+"
+`;
+
+exports[`Generic includer > should sort in descending order with order=desc 1`] = `
+"path: toc.yaml
+items:
+  - name: '20'
+    href: 20.md
+  - name: '10'
+    href: 10.md
+  - name: '2'
+    href: 2.md
+  - name: '1'
+    href: 1.md
+"
+`;
+
+exports[`Generic includer > should sort nested directories naturally 1`] = `
+"path: toc.yaml
+items:
+  - name: chapter-1
+    items:
+      - name: intro
+        href: chapter-1/intro.md
+      - name: section-1
+        href: chapter-1/section-1.md
+      - name: section-2
+        href: chapter-1/section-2.md
+      - name: section-10
+        href: chapter-1/section-10.md
+  - name: chapter-2
+    items:
+      - name: intro
+        href: chapter-2/intro.md
+  - name: chapter-10
+    items:
+      - name: intro
+        href: chapter-10/intro.md
+"
+`;
+
+exports[`Generic includer > should sort numeric filenames with orderBy=natural 1`] = `
+"path: toc.yaml
+items:
+  - name: '1'
+    href: 1.md
+  - name: '2'
+    href: 2.md
+  - name: '9'
+    href: 9.md
+  - name: '10'
+    href: 10.md
+  - name: '11'
+    href: 11.md
+  - name: '20'
+    href: 20.md
+  - name: '100'
+    href: 100.md
+"
+`;
+
+exports[`Generic includer > should sort with orderBy=filename lexicographically 1`] = `
+"path: toc.yaml
+items:
+  - name: '1'
+    href: 1.md
+  - name: '10'
+    href: 10.md
+  - name: '100'
+    href: 100.md
+  - name: '11'
+    href: 11.md
+  - name: '2'
+    href: 2.md
+  - name: '20'
+    href: 20.md
+  - name: '9'
+    href: 9.md
+"
+`;
+
 exports[`Generic includer > should use autotitle option 1`] = `
 "path: toc.yaml
 items:

--- a/src/extensions/generic-includer/index.spec.ts
+++ b/src/extensions/generic-includer/index.spec.ts
@@ -123,4 +123,128 @@ describe('Generic includer', () => {
 
         expect(dump(result)).toMatchSnapshot();
     });
+
+    it('should sort numeric filenames with orderBy=natural', async () => {
+        const {run} = await prepareExtension([
+            [
+                '**/*.md',
+                './test',
+                ['10.md', '2.md', '1.md', '20.md', '11.md', '100.md', '9.md'] as NormalizedPath[],
+            ],
+        ]);
+
+        const result = await getTocHooks(run.toc)
+            .Includer.for('generic')
+            .promise(
+                {path: 'toc.yaml' as NormalizedPath},
+                {
+                    input: './test',
+                    path: './test/toc.yaml',
+                    autotitle: false,
+                    orderBy: 'natural',
+                },
+                'toc.yaml' as NormalizedPath,
+            );
+
+        expect(dump(result)).toMatchSnapshot();
+    });
+
+    it('should sort with orderBy=filename lexicographically', async () => {
+        const {run} = await prepareExtension([
+            [
+                '**/*.md',
+                './test',
+                ['10.md', '2.md', '1.md', '20.md', '11.md', '100.md', '9.md'] as NormalizedPath[],
+            ],
+        ]);
+
+        const result = await getTocHooks(run.toc)
+            .Includer.for('generic')
+            .promise(
+                {path: 'toc.yaml' as NormalizedPath},
+                {
+                    input: './test',
+                    path: './test/toc.yaml',
+                    autotitle: false,
+                    orderBy: 'filename',
+                },
+                'toc.yaml' as NormalizedPath,
+            );
+
+        expect(dump(result)).toMatchSnapshot();
+    });
+
+    it('should sort in descending order with order=desc', async () => {
+        const {run} = await prepareExtension([
+            ['**/*.md', './test', ['1.md', '2.md', '10.md', '20.md'] as NormalizedPath[]],
+        ]);
+
+        const result = await getTocHooks(run.toc)
+            .Includer.for('generic')
+            .promise(
+                {path: 'toc.yaml' as NormalizedPath},
+                {
+                    input: './test',
+                    path: './test/toc.yaml',
+                    autotitle: false,
+                    orderBy: 'natural',
+                    order: 'desc',
+                },
+                'toc.yaml' as NormalizedPath,
+            );
+
+        expect(dump(result)).toMatchSnapshot();
+    });
+
+    it('should sort nested directories naturally', async () => {
+        const {run} = await prepareExtension([
+            [
+                '**/*.md',
+                './test',
+                [
+                    'chapter-10/intro.md',
+                    'chapter-2/intro.md',
+                    'chapter-1/intro.md',
+                    'chapter-1/section-10.md',
+                    'chapter-1/section-2.md',
+                    'chapter-1/section-1.md',
+                ] as NormalizedPath[],
+            ],
+        ]);
+
+        const result = await getTocHooks(run.toc)
+            .Includer.for('generic')
+            .promise(
+                {path: 'toc.yaml' as NormalizedPath},
+                {
+                    input: './test',
+                    path: './test/toc.yaml',
+                    autotitle: false,
+                    orderBy: 'natural',
+                },
+                'toc.yaml' as NormalizedPath,
+            );
+
+        expect(dump(result)).toMatchSnapshot();
+    });
+
+    it('should preserve insertion order without orderBy', async () => {
+        const {run} = await prepareExtension([
+            ['**/*.md', './test', ['banana.md', 'apple.md', 'cherry.md'] as NormalizedPath[]],
+        ]);
+
+        const result = await getTocHooks(run.toc)
+            .Includer.for('generic')
+            .promise(
+                {path: 'toc.yaml' as NormalizedPath},
+                {
+                    input: './test',
+                    path: './test/toc.yaml',
+                    autotitle: false,
+                },
+                'toc.yaml' as NormalizedPath,
+            );
+
+        expect(dump(result)).toMatchSnapshot();
+    });
 });

--- a/src/extensions/generic-includer/index.ts
+++ b/src/extensions/generic-includer/index.ts
@@ -13,10 +13,15 @@ import {dirname, extname, join} from 'node:path';
 import {getHooks as getBaseHooks} from '@diplodoc/cli/lib/program';
 import {getHooks as getTocHooks} from '@diplodoc/cli/lib/toc';
 
+type Order = 'asc' | 'desc';
+type OrderBy = 'filename' | 'natural';
+
 type Options = IncluderOptions<{
     input?: RelativePath;
     autotitle?: boolean;
     linkIndex?: boolean;
+    order?: Order;
+    orderBy?: OrderBy;
 }>;
 
 type Graph = {
@@ -30,7 +35,8 @@ type Run = BaseRun & {
 const EXTENSION = 'GenericIncluder';
 const INCLUDER = 'generic';
 
-// TODO: implement sort
+const naturalCollator = new Intl.Collator(undefined, {numeric: true});
+
 export class Extension implements IExtension {
     apply(program: BaseProgram) {
         getBaseHooks<Run>(program).BeforeAnyRun.tap(EXTENSION, (run) => {
@@ -78,6 +84,29 @@ function pageName(key: string, options: Options) {
     return key as YfmString;
 }
 
+function compareKeys(orderBy: OrderBy): (a: string, b: string) => number {
+    if (orderBy === 'filename') {
+        return (a, b) => {
+            if (a < b) return -1;
+            if (a > b) return 1;
+            return 0;
+        };
+    }
+
+    return naturalCollator.compare;
+}
+
+function sortEntries<T>(entries: [string, T][], options: Options): [string, T][] {
+    if (!options.orderBy) {
+        return entries;
+    }
+
+    const cmp = compareKeys(options.orderBy);
+    const direction = (options.order ?? 'asc') === 'desc' ? -1 : 1;
+
+    return [...entries].sort(([a], [b]) => direction * cmp(a, b));
+}
+
 function fillToc(toc: RawToc, graph: Graph, options: Options) {
     function item([key, value]: [string, Graph | (NormalizedPath & YfmString)]): RawTocItem {
         const name = pageName(key, options);
@@ -86,8 +115,9 @@ function fillToc(toc: RawToc, graph: Graph, options: Options) {
             return {name, href: value};
         }
 
+        const entries = sortEntries(Object.entries(value), options);
+
         if (options.linkIndex) {
-            const entries = Object.entries(value);
             const indexEntry = entries.find(([k]) => k === 'index');
             const childEntries = entries.filter(([k]) => k !== 'index');
 
@@ -103,10 +133,10 @@ function fillToc(toc: RawToc, graph: Graph, options: Options) {
             return result;
         }
 
-        return {name: key as YfmString, items: Object.entries(value).map(item)};
+        return {name: key as YfmString, items: entries.map(item)};
     }
 
-    toc.items = Object.entries(graph).map(item);
+    toc.items = sortEntries(Object.entries(graph), options).map(item);
 
     return toc;
 }


### PR DESCRIPTION
## Summary

Refs #1871. Adds opt-in natural sort to `GenericIncluder` without changing the default behavior.

`GenericIncluder` had `// TODO: implement sort` and emitted files in non-deterministic order (depended on `glob`/FS + JS object key semantics). For numerically-named docs this produced sequences like `9, 8, 7, ..., 1, 16, 15, ..., 10` instead of the expected `1, 2, ..., 9, 10, 11, ..., 20`.

Two new options, applied recursively at every TOC level:

- `orderBy: 'natural' | 'filename'` — **opt-in**, when omitted nothing changes. `natural` uses `Intl.Collator(numeric: true)`, which correctly handles both pure numeric names (`1, 2, 10, 20`) and mixed names (`chapter-1, chapter-2, chapter-10`). `filename` produces strict lexicographic order.
- `order: 'asc' | 'desc'` — default `asc`, only takes effect when `orderBy` is set.

## Backward compatibility

Default behavior is unchanged. Existing `toc.yaml` configs produce the same output as before.

The user from #1871 can resolve their issue today by adding `orderBy: 'natural'` to their includer config.

Flipping the default to `natural` is a behavior change and is tracked separately for v6 (#1899).

## Example

```yaml
- name: docs
  include:
    path: .
    includers:
      - name: generic
        orderBy: natural    # 1.md, 2.md, ..., 10.md, 20.md, 100.md
    mode: link
```