### PR TITLE
feat(build): emit build stats file with timing and counters

### DIFF
--- a/src/commands/build/features/build-stats/__snapshots__/index.spec.ts.snap
+++ b/src/commands/build/features/build-stats/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,69 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`BuildStats > snapshot > emits a stable JSON shape for a typical build 1`] = `
+{
+  "build": {
+    "configHash": "<NORMALIZED>",
+    "durationMs": "<NUMBER>",
+    "features": [
+      "allowHtml",
+      "buildStats",
+      "sanitizeHtml",
+      "staticContent",
+    ],
+    "finishedAt": "<NORMALIZED>",
+    "inputDir": "<NORMALIZED>",
+    "langs": [
+      "en",
+      "ru",
+    ],
+    "outputDir": "<NORMALIZED>",
+    "outputFormat": "html",
+    "phasesMs": {
+      "entries": "<NUMBER>",
+      "finalize": "<NUMBER>",
+      "prepare": "<NUMBER>",
+    },
+    "startedAt": "<NORMALIZED>",
+    "worker": {
+      "maxOldSpace": 0,
+    },
+  },
+  "cli": {
+    "arch": "<NORMALIZED>",
+    "node": "<NORMALIZED>",
+    "osRelease": "<NORMALIZED>",
+    "platform": "<NORMALIZED>",
+    "version": "<NORMALIZED>",
+  },
+  "counters": {
+    "entriesByExtension": {
+      ".md": 2,
+      ".yaml": 1,
+    },
+    "entriesByLang": {
+      "en": 2,
+      "ru": 1,
+    },
+    "entriesPlanned": 0,
+    "entriesProcessed": 3,
+    "errors": 0,
+    "missed": 0,
+    "tocs": 0,
+    "warnings": 0,
+  },
+  "output": {
+    "bytesByExtension": {
+      ".css": 512,
+      ".html": 6144,
+    },
+    "files": 4,
+    "largestFile": {
+      "bytes": 4096,
+      "path": "en/guide.html",
+    },
+    "totalBytes": 6656,
+  },
+  "schemaVersion": 1,
+}
+`;

--- a/src/commands/build/features/build-stats/__snapshots__/index.spec.ts.snap
+++ b/src/commands/build/features/build-stats/__snapshots__/index.spec.ts.snap
@@ -37,6 +37,7 @@ exports[`BuildStats > snapshot > emits a stable JSON shape for a typical build 1
     "version": "<NORMALIZED>",
   },
   "counters": {
+    "contentBytes": 21,
     "entriesByExtension": {
       ".md": 2,
       ".yaml": 1,
@@ -48,7 +49,14 @@ exports[`BuildStats > snapshot > emits a stable JSON shape for a typical build 1
     "entriesPlanned": 0,
     "entriesProcessed": 3,
     "errors": 0,
-    "missed": 0,
+    "graph": {
+      "edges": 3,
+      "entries": 3,
+      "missed": 1,
+      "resources": 1,
+      "sources": 1,
+    },
+    "headings": 5,
     "tocs": 0,
     "warnings": 0,
   },

--- a/src/commands/build/features/build-stats/__snapshots__/index.spec.ts.snap
+++ b/src/commands/build/features/build-stats/__snapshots__/index.spec.ts.snap
@@ -3,7 +3,6 @@
 exports[`BuildStats > snapshot > emits a stable JSON shape for a typical build 1`] = `
 {
   "build": {
-    "configHash": "<NORMALIZED>",
     "durationMs": "<NUMBER>",
     "features": [
       "allowHtml",
@@ -17,6 +16,7 @@ exports[`BuildStats > snapshot > emits a stable JSON shape for a typical build 1
       "en",
       "ru",
     ],
+    "memoryUsageMb": "<NUMBER>",
     "outputDir": "<NORMALIZED>",
     "outputFormat": "html",
     "phasesMs": {
@@ -66,10 +66,6 @@ exports[`BuildStats > snapshot > emits a stable JSON shape for a typical build 1
       ".html": 6144,
     },
     "files": 4,
-    "largestFile": {
-      "bytes": 4096,
-      "path": "en/guide.html",
-    },
     "totalBytes": 6656,
   },
   "schemaVersion": 1,

--- a/src/commands/build/features/build-stats/__snapshots__/index.spec.ts.snap
+++ b/src/commands/build/features/build-stats/__snapshots__/index.spec.ts.snap
@@ -49,6 +49,9 @@ exports[`BuildStats > snapshot > emits a stable JSON shape for a typical build 1
     "entriesPlanned": 0,
     "entriesProcessed": 3,
     "errors": 0,
+    "errorsByCode": {
+      "YFM016": 2,
+    },
     "graph": {
       "edges": 3,
       "entries": 3,
@@ -59,6 +62,10 @@ exports[`BuildStats > snapshot > emits a stable JSON shape for a typical build 1
     "headings": 5,
     "tocs": 0,
     "warnings": 0,
+    "warningsByCode": {
+      "(uncoded)": 1,
+      "YFM013": 1,
+    },
   },
   "output": {
     "bytesByExtension": {

--- a/src/commands/build/features/build-stats/config.ts
+++ b/src/commands/build/features/build-stats/config.ts
@@ -1,0 +1,17 @@
+import {bold} from 'chalk';
+import dedent from 'ts-dedent';
+
+import {option} from '~/core/config';
+
+const buildStats = option({
+    flags: '--build-stats',
+    desc: dedent`
+        Output a build stats file (${bold('yfm-build-stats.json')}) with timing,
+        environment info and counters. Intended for diagnostics, CI dashboards
+        and regression detection.
+    `,
+});
+
+export const options = {
+    buildStats,
+};

--- a/src/commands/build/features/build-stats/index.spec.ts
+++ b/src/commands/build/features/build-stats/index.spec.ts
@@ -92,10 +92,32 @@ describe('BuildStats', () => {
             const onEntry = tapByName(getBuildHooks(build).Entry.for('html').taps, 'BuildStats');
             const after = tapByName(getBaseHooks(build).AfterAnyRun.taps, 'BuildStats');
 
+            const md = (h: number, html: string) => ({
+                leading: false,
+                headings: new Array(h).fill({content: 'h', location: {}}),
+                html,
+            });
+            const yaml = {leading: true, data: {}};
+
+            // Populate the graph the way real markdown processing would: pages
+            // are `entry`, included files are `source`, image/style assets are
+            // `resource`, and a missing file is `missed`. Edges point from page
+            // to its deps.
+            const rel = run.entry.relations;
+            rel.addNode('en/index.md' as NormalizedPath, {type: 'entry'});
+            rel.addNode('en/guide.yaml' as NormalizedPath, {type: 'entry'});
+            rel.addNode('ru/index.md' as NormalizedPath, {type: 'entry'});
+            rel.addNode('en/_includes/intro.md' as NormalizedPath, {type: 'source'});
+            rel.addNode('en/_assets/logo.png' as NormalizedPath, {type: 'resource'});
+            rel.addNode('en/missing.md' as NormalizedPath, {type: 'missed'});
+            rel.addDependency('en/index.md', 'en/_includes/intro.md');
+            rel.addDependency('en/index.md', 'en/_assets/logo.png');
+            rel.addDependency('en/index.md', 'en/missing.md');
+
             await before(run);
-            await onEntry(run, 'en/index.md' as NormalizedPath, {});
-            await onEntry(run, 'en/guide.yaml' as NormalizedPath, {});
-            await onEntry(run, 'ru/index.md' as NormalizedPath, {});
+            await onEntry(run, 'en/index.md' as NormalizedPath, md(3, '<p>hello</p>'));
+            await onEntry(run, 'en/guide.yaml' as NormalizedPath, yaml);
+            await onEntry(run, 'ru/index.md' as NormalizedPath, md(2, '<p>hi</p>'));
             await after(run);
 
             expect(writtenJson).toBeDefined();

--- a/src/commands/build/features/build-stats/index.spec.ts
+++ b/src/commands/build/features/build-stats/index.spec.ts
@@ -1,96 +1,131 @@
-import {describe, expect, it} from 'vitest';
+import type {BuildConfig} from '../..';
+import type {Stats} from 'node:fs';
+import type {FullTap} from 'tapable';
 
-import {collectFeatures, hashConfig, stableStringify, toLangCode} from './index';
+import {describe, expect, it, vi} from 'vitest';
+import {when} from 'vitest-when';
 
-describe('Build stats feature', () => {
+import {getHooks as getBaseHooks} from '~/core/program';
+
+import {setupRun} from '../../__tests__';
+import {getHooks as getBuildHooks} from '../../hooks';
+import {Build} from '../..';
+
+import {BuildStats, collectFeatures, hashConfig} from './index';
+
+describe('BuildStats', () => {
     describe('collectFeatures', () => {
-        it('returns enabled boolean flags sorted alphabetically', () => {
+        it('returns config keys with literal `true`, sorted, ignoring truthy non-`true` values', () => {
             const features = collectFeatures({
                 singlePage: true,
                 staticContent: true,
                 addMapFile: true,
+                allowHtml: 1, // truthy but not `true`
+                sanitizeHtml: 'yes', // string
+                contributors: false,
+                lint: {enabled: true}, // nested — top-level only
             });
 
             expect(features).toEqual(['addMapFile', 'singlePage', 'staticContent']);
         });
-
-        it('skips flags that are not strictly `true`', () => {
-            const features = collectFeatures({
-                singlePage: true,
-                staticContent: false,
-                addMapFile: 1, // truthy but not `true`
-                allowHtml: 'yes', // string
-                neuroExpert: undefined,
-                contributors: null,
-                lint: {enabled: true}, // nested object — top-level only
-            });
-
-            expect(features).toEqual(['singlePage']);
-        });
-
-        it('returns empty array when nothing is enabled', () => {
-            expect(collectFeatures({})).toEqual([]);
-            expect(
-                collectFeatures({
-                    addMapFile: false,
-                    singlePage: false,
-                }),
-            ).toEqual([]);
-        });
-    });
-
-    describe('stableStringify', () => {
-        it('produces the same output regardless of key insertion order', () => {
-            const a = stableStringify({b: 1, a: 2, c: 3});
-            const b = stableStringify({c: 3, a: 2, b: 1});
-
-            expect(a).toBe(b);
-            expect(a).toBe('{"a":2,"b":1,"c":3}');
-        });
-
-        it('sorts keys recursively in nested objects', () => {
-            const out = stableStringify({outer: {z: 1, a: 2}});
-
-            expect(out).toBe('{"outer":{"a":2,"z":1}}');
-        });
-
-        it('preserves array order', () => {
-            expect(stableStringify([3, 1, 2])).toBe('[3,1,2]');
-        });
-
-        it('handles primitives and null', () => {
-            expect(stableStringify(null)).toBe('null');
-            expect(stableStringify('x')).toBe('"x"');
-            expect(stableStringify(42)).toBe('42');
-            expect(stableStringify(true)).toBe('true');
-        });
-
-        it('serializes undefined as null', () => {
-            expect(stableStringify(undefined)).toBe('null');
-        });
     });
 
     describe('hashConfig', () => {
-        it('returns a stable 16-char hex digest for equal configs', () => {
-            const hashA = hashConfig({a: 1, b: 2});
-            const hashB = hashConfig({b: 2, a: 1});
-
-            expect(hashA).toBe(hashB);
-            expect(hashA).toMatch(/^[0-9a-f]{16}$/);
+        it('is stable across key insertion order', () => {
+            expect(hashConfig({b: 1, a: 2, c: [1, 2]})).toBe(hashConfig({c: [1, 2], a: 2, b: 1}));
         });
 
-        it('produces different digests for different configs', () => {
+        it('changes when any value changes', () => {
             expect(hashConfig({a: 1})).not.toBe(hashConfig({a: 2}));
         });
     });
 
-    describe('toLangCode', () => {
-        it('returns the string as-is when given a string', () => {
-            expect(toLangCode('en')).toBe('en');
-        });
+    describe('snapshot', () => {
+        it('emits a stable JSON shape for a typical build', async () => {
+            const build = new Build();
+            new BuildStats().apply(build);
 
-        it('extracts the lang field from an extended-lang object', () => {
-            expect(toLangCode({lang: 'ru', tld: 'ru'} as {lang: string})).toBe('ru');
+            const run = setupRun({
+                buildStats: true,
+                outputFormat: 'html',
+                langs: ['en', 'ru'],
+                staticContent: true,
+                allowHtml: true,
+                sanitizeHtml: true,
+                workerMaxOldSpace: 0,
+            } as unknown as BuildConfig);
+
+            when(run.glob)
+                .calledWith('**/*', expect.anything())
+                .thenResolve([
+                    'en/index.html',
+                    'en/guide.html',
+                    'ru/index.html',
+                    'assets/style.css',
+                ] as NormalizedPath[]);
+
+            const sizes: Record<string, number> = {
+                'en/index.html': 1024,
+                'en/guide.html': 4096,
+                'ru/index.html': 1024,
+                'assets/style.css': 512,
+            };
+            vi.spyOn(run.fs, 'stat').mockImplementation((async (path: string) => {
+                const key = Object.keys(sizes).find((k) => path.endsWith(k));
+                return {size: key ? sizes[key] : 0} as Stats;
+            }) as unknown as typeof run.fs.stat);
+
+            let writtenJson: string | undefined;
+            vi.spyOn(run, 'write').mockImplementation(async (path, content) => {
+                if (String(path).endsWith('yfm-build-stats.json')) {
+                    writtenJson = content;
+                }
+            });
+
+            const tapByName = (taps: FullTap[], name: string) => {
+                const tap = taps.find((t) => t.name === name);
+                if (!tap) throw new Error(`tap ${name} not registered`);
+                return tap.fn;
+            };
+
+            const before = tapByName(getBaseHooks(build).BeforeAnyRun.taps, 'BuildStats');
+            const onEntry = tapByName(getBuildHooks(build).Entry.for('html').taps, 'BuildStats');
+            const after = tapByName(getBaseHooks(build).AfterAnyRun.taps, 'BuildStats');
+
+            await before(run);
+            await onEntry(run, 'en/index.md' as NormalizedPath, {});
+            await onEntry(run, 'en/guide.yaml' as NormalizedPath, {});
+            await onEntry(run, 'ru/index.md' as NormalizedPath, {});
+            await after(run);
+
+            expect(writtenJson).toBeDefined();
+            expect(sanitize(JSON.parse(writtenJson as string))).toMatchSnapshot();
         });
     });
 });
+
+// Volatile fields are replaced with placeholders so the snapshot only asserts
+// shape and computed values that don't depend on the host or wall clock.
+function sanitize(stats: Hash<unknown>): unknown {
+    const PLACEHOLDER = '<NORMALIZED>';
+    const cli = stats.cli as Hash<unknown>;
+    const _build = stats.build as Hash<unknown>;
+    const phases = _build.phasesMs as Record<string, number | null>;
+
+    return {
+        ...stats,
+        cli: Object.fromEntries(Object.keys(cli).map((k) => [k, PLACEHOLDER])),
+        build: {
+            ..._build,
+            startedAt: PLACEHOLDER,
+            finishedAt: PLACEHOLDER,
+            durationMs: typeof _build.durationMs === 'number' ? '<NUMBER>' : _build.durationMs,
+            phasesMs: Object.fromEntries(
+                Object.entries(phases).map(([k, v]) => [k, v === null ? null : '<NUMBER>']),
+            ),
+            inputDir: PLACEHOLDER,
+            outputDir: PLACEHOLDER,
+            configHash: PLACEHOLDER,
+        },
+    };
+}

--- a/src/commands/build/features/build-stats/index.spec.ts
+++ b/src/commands/build/features/build-stats/index.spec.ts
@@ -1,0 +1,96 @@
+import {describe, expect, it} from 'vitest';
+
+import {collectFeatures, hashConfig, stableStringify, toLangCode} from './index';
+
+describe('Build stats feature', () => {
+    describe('collectFeatures', () => {
+        it('returns enabled boolean flags sorted alphabetically', () => {
+            const features = collectFeatures({
+                singlePage: true,
+                staticContent: true,
+                addMapFile: true,
+            });
+
+            expect(features).toEqual(['addMapFile', 'singlePage', 'staticContent']);
+        });
+
+        it('skips flags that are not strictly `true`', () => {
+            const features = collectFeatures({
+                singlePage: true,
+                staticContent: false,
+                addMapFile: 1, // truthy but not `true`
+                allowHtml: 'yes', // string
+                neuroExpert: undefined,
+                contributors: null,
+                lint: {enabled: true}, // nested object — top-level only
+            });
+
+            expect(features).toEqual(['singlePage']);
+        });
+
+        it('returns empty array when nothing is enabled', () => {
+            expect(collectFeatures({})).toEqual([]);
+            expect(
+                collectFeatures({
+                    addMapFile: false,
+                    singlePage: false,
+                }),
+            ).toEqual([]);
+        });
+    });
+
+    describe('stableStringify', () => {
+        it('produces the same output regardless of key insertion order', () => {
+            const a = stableStringify({b: 1, a: 2, c: 3});
+            const b = stableStringify({c: 3, a: 2, b: 1});
+
+            expect(a).toBe(b);
+            expect(a).toBe('{"a":2,"b":1,"c":3}');
+        });
+
+        it('sorts keys recursively in nested objects', () => {
+            const out = stableStringify({outer: {z: 1, a: 2}});
+
+            expect(out).toBe('{"outer":{"a":2,"z":1}}');
+        });
+
+        it('preserves array order', () => {
+            expect(stableStringify([3, 1, 2])).toBe('[3,1,2]');
+        });
+
+        it('handles primitives and null', () => {
+            expect(stableStringify(null)).toBe('null');
+            expect(stableStringify('x')).toBe('"x"');
+            expect(stableStringify(42)).toBe('42');
+            expect(stableStringify(true)).toBe('true');
+        });
+
+        it('serializes undefined as null', () => {
+            expect(stableStringify(undefined)).toBe('null');
+        });
+    });
+
+    describe('hashConfig', () => {
+        it('returns a stable 16-char hex digest for equal configs', () => {
+            const hashA = hashConfig({a: 1, b: 2});
+            const hashB = hashConfig({b: 2, a: 1});
+
+            expect(hashA).toBe(hashB);
+            expect(hashA).toMatch(/^[0-9a-f]{16}$/);
+        });
+
+        it('produces different digests for different configs', () => {
+            expect(hashConfig({a: 1})).not.toBe(hashConfig({a: 2}));
+        });
+    });
+
+    describe('toLangCode', () => {
+        it('returns the string as-is when given a string', () => {
+            expect(toLangCode('en')).toBe('en');
+        });
+
+        it('extracts the lang field from an extended-lang object', () => {
+            expect(toLangCode({lang: 'ru', tld: 'ru'} as {lang: string})).toBe('ru');
+        });
+    });
+});

--- a/src/commands/build/features/build-stats/index.spec.ts
+++ b/src/commands/build/features/build-stats/index.spec.ts
@@ -11,7 +11,7 @@ import {setupRun} from '../../__tests__';
 import {getHooks as getBuildHooks} from '../../hooks';
 import {Build} from '../..';
 
-import {BuildStats, collectFeatures, hashConfig} from './index';
+import {BuildStats, collectFeatures} from './index';
 
 describe('BuildStats', () => {
     describe('collectFeatures', () => {
@@ -27,16 +27,6 @@ describe('BuildStats', () => {
             });
 
             expect(features).toEqual(['addMapFile', 'singlePage', 'staticContent']);
-        });
-    });
-
-    describe('hashConfig', () => {
-        it('is stable across key insertion order', () => {
-            expect(hashConfig({b: 1, a: 2, c: [1, 2]})).toBe(hashConfig({c: [1, 2], a: 2, b: 1}));
-        });
-
-        it('changes when any value changes', () => {
-            expect(hashConfig({a: 1})).not.toBe(hashConfig({a: 2}));
         });
     });
 
@@ -147,7 +137,8 @@ function sanitize(stats: Hash<unknown>): unknown {
             ),
             inputDir: PLACEHOLDER,
             outputDir: PLACEHOLDER,
-            configHash: PLACEHOLDER,
+            memoryUsageMb:
+                typeof _build.memoryUsageMb === 'number' ? '<NUMBER>' : _build.memoryUsageMb,
         },
     };
 }

--- a/src/commands/build/features/build-stats/index.spec.ts
+++ b/src/commands/build/features/build-stats/index.spec.ts
@@ -62,7 +62,10 @@ describe('BuildStats', () => {
                 'assets/style.css': 512,
             };
             vi.spyOn(run.fs, 'stat').mockImplementation((async (path: string) => {
-                const key = Object.keys(sizes).find((k) => path.endsWith(k));
+                // Normalize backslashes — on Windows `join` produces `\` paths
+                // but the fixture keys use forward slashes.
+                const normalized = path.replace(/\\/g, '/');
+                const key = Object.keys(sizes).find((k) => normalized.endsWith(k));
                 return {size: key ? sizes[key] : 0} as Stats;
             }) as unknown as typeof run.fs.stat);
 

--- a/src/commands/build/features/build-stats/index.spec.ts
+++ b/src/commands/build/features/build-stats/index.spec.ts
@@ -6,6 +6,7 @@ import {describe, expect, it, vi} from 'vitest';
 import {when} from 'vitest-when';
 
 import {getHooks as getBaseHooks} from '~/core/program';
+import {getHooks as getLoggerHooks} from '~/core/logger';
 
 import {setupRun} from '../../__tests__';
 import {getHooks as getBuildHooks} from '../../hooks';
@@ -108,6 +109,17 @@ describe('BuildStats', () => {
             await onEntry(run, 'en/index.md' as NormalizedPath, md(3, '<p>hello</p>'));
             await onEntry(run, 'en/guide.yaml' as NormalizedPath, yaml);
             await onEntry(run, 'ru/index.md' as NormalizedPath, md(2, '<p>hi</p>'));
+
+            // Drive the logger hooks directly: setupRun mocks `logger.warn` /
+            // `logger.error` topics, which short-circuits the internal hook
+            // dispatch. We trigger the hooks so the by-code bucketing logic is
+            // actually exercised.
+            const loggerHooks = getLoggerHooks(run.logger);
+            loggerHooks.Warn.call('en/page.md: YFM013 / File asset limit exceeded');
+            loggerHooks.Warn.call('Some plain warning without a code');
+            loggerHooks.Error.call('en/cycle.md: YFM016 / The file is included in itself');
+            loggerHooks.Error.call('en/cycle2.md: YFM016 / Another cycle');
+
             await after(run);
 
             expect(writtenJson).toBeDefined();

--- a/src/commands/build/features/build-stats/index.ts
+++ b/src/commands/build/features/build-stats/index.ts
@@ -2,7 +2,7 @@ import type {Command} from '~/core/config';
 import type {Build, EntryInfo, Run} from '~/commands/build';
 
 import {extname, join} from 'node:path';
-import {arch, platform, release as osRelease} from 'node:os';
+import {arch, release as osRelease, platform} from 'node:os';
 import {createHash} from 'node:crypto';
 
 import {getHooks as getBaseHooks} from '~/core/program';

--- a/src/commands/build/features/build-stats/index.ts
+++ b/src/commands/build/features/build-stats/index.ts
@@ -214,7 +214,7 @@ export class BuildStats {
     }
 }
 
-export function toLangCode(lang: string | {lang: string}): string {
+function toLangCode(lang: string | {lang: string}): string {
     return typeof lang === 'string' ? lang : lang.lang;
 }
 
@@ -237,7 +237,7 @@ function countMissed(run: Run): number {
     return count;
 }
 
-export function stableStringify(value: unknown): string {
+function stableStringify(value: unknown): string {
     if (value === null || typeof value !== 'object') {
         return JSON.stringify(value) ?? 'null';
     }

--- a/src/commands/build/features/build-stats/index.ts
+++ b/src/commands/build/features/build-stats/index.ts
@@ -1,5 +1,5 @@
 import type {Command} from '~/core/config';
-import type {Build, Run} from '~/commands/build';
+import type {Build, EntryInfo, Run} from '~/commands/build';
 
 import {extname, join} from 'node:path';
 import {arch, platform, release as osRelease} from 'node:os';
@@ -65,7 +65,23 @@ type BuildStatsFormat = {
         entriesProcessed: number;
         entriesByExtension: CountByKey;
         entriesByLang: CountByKey;
-        missed: number;
+        // Sums collected from per-entry `Entry`-hook info. Markdown only —
+        // leading (yaml) entries don't have headings/html.
+        headings: number;
+        contentBytes: number;
+        // Aggregated from `run.entry.relations` after build:
+        //   entries   — pages themselves (md/yaml leading)
+        //   sources   — included markdown files + autotitle link targets
+        //   resources — image/video assets + meta script/style references
+        //   missed    — paths the build tried to read but didn't find
+        //   edges     — total dependency edges (rough connectedness signal)
+        graph: {
+            entries: number;
+            sources: number;
+            resources: number;
+            missed: number;
+            edges: number;
+        };
         warnings: number;
         errors: number;
     };
@@ -92,6 +108,10 @@ export class BuildStats {
     private entriesByExtension: CountByKey = {};
 
     private entriesByLang: CountByKey = {};
+
+    private headings = 0;
+
+    private contentBytes = 0;
 
     apply(program: Build) {
         getBaseHooks(program).Command.tap('BuildStats', (command: Command) => {
@@ -123,7 +143,7 @@ export class BuildStats {
             this.startedAt = Date.now();
         });
 
-        const onEntry = (run: Run, entry: NormalizedPath) => {
+        const onEntry = (run: Run, entry: NormalizedPath, info: DeepFrozen<EntryInfo>) => {
             if (!run.config.buildStats) {
                 return;
             }
@@ -141,6 +161,12 @@ export class BuildStats {
 
             const lang = langFromPath(entry, run.config) || '<none>';
             this.entriesByLang[lang] = (this.entriesByLang[lang] ?? 0) + 1;
+
+            // Markdown-only payload: leading (yaml) pages don't have headings/html.
+            if (info.leading === false) {
+                this.headings += info.headings?.length ?? 0;
+                this.contentBytes += info.html?.length ?? 0;
+            }
         };
 
         getBuildHooks(program).Entry.for('md').tap('BuildStats', onEntry);
@@ -193,7 +219,9 @@ export class BuildStats {
                     entriesProcessed: this.entryCount,
                     entriesByExtension: this.entriesByExtension,
                     entriesByLang: this.entriesByLang,
-                    missed: countMissed(run),
+                    headings: this.headings,
+                    contentBytes: this.contentBytes,
+                    graph: collectGraph(run),
                     warnings: logCounts.warn,
                     errors: logCounts.error,
                 },
@@ -211,6 +239,8 @@ export class BuildStats {
         this.entryCount = 0;
         this.entriesByExtension = {};
         this.entriesByLang = {};
+        this.headings = 0;
+        this.contentBytes = 0;
     }
 }
 
@@ -226,15 +256,39 @@ export function collectFeatures(config: Hash<unknown>): string[] {
         .sort();
 }
 
-function countMissed(run: Run): number {
-    let count = 0;
-    for (const node of run.entry.relations.overallOrder()) {
-        const data = run.entry.relations.getNodeData(node) as {type?: string} | undefined;
-        if (data?.type === 'missed') {
-            count++;
+type GraphCounters = BuildStatsFormat['counters']['graph'];
+
+function collectGraph(run: Run): GraphCounters {
+    const relations = run.entry.relations;
+    const counters: GraphCounters = {
+        entries: 0,
+        sources: 0,
+        resources: 0,
+        missed: 0,
+        edges: 0,
+    };
+
+    const nodes = relations.overallOrder();
+    for (const node of nodes) {
+        const data = relations.getNodeData(node) as {type?: string} | undefined;
+        switch (data?.type) {
+            case 'entry':
+                counters.entries++;
+                break;
+            case 'source':
+                counters.sources++;
+                break;
+            case 'resource':
+                counters.resources++;
+                break;
+            case 'missed':
+                counters.missed++;
+                break;
         }
+        counters.edges += relations.directDependenciesOf(node).length;
     }
-    return count;
+
+    return counters;
 }
 
 function stableStringify(value: unknown): string {

--- a/src/commands/build/features/build-stats/index.ts
+++ b/src/commands/build/features/build-stats/index.ts
@@ -17,28 +17,6 @@ import {options} from './config';
 const STATS_FILENAME = 'yfm-build-stats.json';
 const SCHEMA_VERSION = 1;
 
-// Top-level boolean toggles we surface in the report. New flags can be appended
-// without breaking consumers — anything not listed here is just ignored.
-const KNOWN_FEATURE_FLAGS = [
-    'addAlternateMeta',
-    'addMapFile',
-    'addMetadataMeta',
-    'addResourcesMeta',
-    'addSystemMeta',
-    'allowHtml',
-    'buildManifest',
-    'contributors',
-    'crawlerManifest',
-    'mergeIncludes',
-    'pdfDebug',
-    'rawAddMeta',
-    'removeEmptyTocItems',
-    'removeHiddenTocItems',
-    'sanitizeHtml',
-    'singlePage',
-    'staticContent',
-] as const;
-
 type CountByKey = Record<string, number>;
 
 type OutputInfo = {
@@ -236,12 +214,16 @@ export class BuildStats {
     }
 }
 
-function toLangCode(lang: string | {lang: string}): string {
+export function toLangCode(lang: string | {lang: string}): string {
     return typeof lang === 'string' ? lang : lang.lang;
 }
 
-function collectFeatures(config: Hash<unknown>): string[] {
-    return KNOWN_FEATURE_FLAGS.filter((flag) => config[flag] === true);
+// Surface every config field that resolved to literal `true`. No whitelist —
+// whatever flags the user (or defaults) turned on shows up here.
+export function collectFeatures(config: Hash<unknown>): string[] {
+    return Object.keys(config)
+        .filter((key) => config[key] === true)
+        .sort();
 }
 
 function countMissed(run: Run): number {
@@ -255,7 +237,7 @@ function countMissed(run: Run): number {
     return count;
 }
 
-function stableStringify(value: unknown): string {
+export function stableStringify(value: unknown): string {
     if (value === null || typeof value !== 'object') {
         return JSON.stringify(value) ?? 'null';
     }
@@ -272,12 +254,25 @@ function stableStringify(value: unknown): string {
     );
 }
 
-function hashConfig(config: unknown): string {
+export function hashConfig(config: unknown): string {
     return createHash('sha256').update(stableStringify(config)).digest('hex').slice(0, 16);
 }
 
+const EMPTY_OUTPUT: OutputInfo = {
+    files: 0,
+    totalBytes: 0,
+    bytesByExtension: {},
+    largestFile: null,
+};
+
 async function readOutputSize(run: Run): Promise<OutputInfo> {
-    const files = await run.glob('**/*', {cwd: run.output});
+    let files: NormalizedPath[];
+    try {
+        files = await run.glob('**/*', {cwd: run.output});
+    } catch (error) {
+        run.logger.warn(`BuildStats: failed to glob output directory: ${error}`);
+        return EMPTY_OUTPUT;
+    }
 
     let totalBytes = 0;
     let largestFile: OutputInfo['largestFile'] = null;

--- a/src/commands/build/features/build-stats/index.ts
+++ b/src/commands/build/features/build-stats/index.ts
@@ -1,0 +1,310 @@
+import type {Command} from '~/core/config';
+import type {Build, Run} from '~/commands/build';
+
+import {extname, join} from 'node:path';
+import {arch, platform, release as osRelease} from 'node:os';
+import {createHash} from 'node:crypto';
+
+import {getHooks as getBaseHooks} from '~/core/program';
+import {getHooks as getBuildHooks} from '~/commands/build';
+import {valuable} from '~/core/config';
+import {VERSION} from '~/constants';
+import {stats as loggerStats} from '~/core/logger';
+import {langFromPath} from '~/core/utils';
+
+import {options} from './config';
+
+const STATS_FILENAME = 'yfm-build-stats.json';
+const SCHEMA_VERSION = 1;
+
+// Top-level boolean toggles we surface in the report. New flags can be appended
+// without breaking consumers — anything not listed here is just ignored.
+const KNOWN_FEATURE_FLAGS = [
+    'addAlternateMeta',
+    'addMapFile',
+    'addMetadataMeta',
+    'addResourcesMeta',
+    'addSystemMeta',
+    'allowHtml',
+    'buildManifest',
+    'contributors',
+    'crawlerManifest',
+    'mergeIncludes',
+    'pdfDebug',
+    'rawAddMeta',
+    'removeEmptyTocItems',
+    'removeHiddenTocItems',
+    'sanitizeHtml',
+    'singlePage',
+    'staticContent',
+] as const;
+
+type CountByKey = Record<string, number>;
+
+type OutputInfo = {
+    files: number;
+    totalBytes: number;
+    bytesByExtension: CountByKey;
+    largestFile: {path: string; bytes: number} | null;
+};
+
+type BuildStatsFormat = {
+    schemaVersion: typeof SCHEMA_VERSION;
+    cli: {
+        version: string;
+        node: string;
+        platform: string;
+        arch: string;
+        osRelease: string;
+    };
+    build: {
+        startedAt: string;
+        finishedAt: string;
+        durationMs: number;
+        // Coarse phase split derived from Entry hook timestamps.
+        // `prepare` covers everything before the first entry was processed,
+        // `entries` is the time between the first and last entry,
+        // `finalize` is what happened after the last entry (release + aggregators).
+        // Phases are null when no entries were produced.
+        phasesMs: {
+            prepare: number | null;
+            entries: number | null;
+            finalize: number | null;
+        };
+        outputFormat: string;
+        langs: string[];
+        inputDir: string;
+        outputDir: string;
+        configHash: string;
+        features: string[];
+        worker: {
+            maxOldSpace: number | null;
+        };
+    };
+    counters: {
+        tocs: number;
+        entriesPlanned: number;
+        entriesProcessed: number;
+        entriesByExtension: CountByKey;
+        entriesByLang: CountByKey;
+        missed: number;
+        warnings: number;
+        errors: number;
+    };
+    output: OutputInfo;
+};
+
+export type BuildStatsArgs = {
+    buildStats: boolean;
+};
+
+export type BuildStatsConfig = {
+    buildStats: boolean;
+};
+
+export class BuildStats {
+    private startedAt = 0;
+
+    private firstEntryAt = 0;
+
+    private lastEntryAt = 0;
+
+    private entryCount = 0;
+
+    private entriesByExtension: CountByKey = {};
+
+    private entriesByLang: CountByKey = {};
+
+    apply(program: Build) {
+        getBaseHooks(program).Command.tap('BuildStats', (command: Command) => {
+            command.addOption(options.buildStats);
+        });
+
+        getBaseHooks(program).Config.tapPromise('BuildStats', async (config, args) => {
+            let buildStats = false;
+
+            if (valuable(config.buildStats)) {
+                buildStats = Boolean(config.buildStats);
+            }
+
+            if (valuable(args.buildStats)) {
+                buildStats = Boolean(args.buildStats);
+            }
+
+            config.buildStats = buildStats;
+
+            return config;
+        });
+
+        getBaseHooks<Run>(program).BeforeAnyRun.tap('BuildStats', (run) => {
+            if (!run.config.buildStats) {
+                return;
+            }
+
+            this.reset();
+            this.startedAt = Date.now();
+        });
+
+        const onEntry = (run: Run, entry: NormalizedPath) => {
+            if (!run.config.buildStats) {
+                return;
+            }
+
+            const now = Date.now();
+            if (!this.firstEntryAt) {
+                this.firstEntryAt = now;
+            }
+            this.lastEntryAt = now;
+
+            this.entryCount++;
+
+            const ext = (extname(entry) || '<noext>').toLowerCase();
+            this.entriesByExtension[ext] = (this.entriesByExtension[ext] ?? 0) + 1;
+
+            const lang = langFromPath(entry, run.config) || '<none>';
+            this.entriesByLang[lang] = (this.entriesByLang[lang] ?? 0) + 1;
+        };
+
+        getBuildHooks(program).Entry.for('md').tap('BuildStats', onEntry);
+        getBuildHooks(program).Entry.for('html').tap('BuildStats', onEntry);
+
+        getBaseHooks<Run>(program).AfterAnyRun.tapPromise('BuildStats', async (run) => {
+            if (!run.config.buildStats) {
+                return;
+            }
+
+            const finishedAt = Date.now();
+            const logCounts = loggerStats(run.logger);
+
+            const output = await readOutputSize(run);
+
+            const stats: BuildStatsFormat = {
+                schemaVersion: SCHEMA_VERSION,
+                cli: {
+                    version: VERSION,
+                    node: process.version,
+                    platform: platform(),
+                    arch: arch(),
+                    osRelease: osRelease(),
+                },
+                build: {
+                    startedAt: new Date(this.startedAt).toISOString(),
+                    finishedAt: new Date(finishedAt).toISOString(),
+                    durationMs: finishedAt - this.startedAt,
+                    phasesMs: {
+                        prepare: this.firstEntryAt ? this.firstEntryAt - this.startedAt : null,
+                        entries: this.firstEntryAt ? this.lastEntryAt - this.firstEntryAt : null,
+                        finalize: this.lastEntryAt ? finishedAt - this.lastEntryAt : null,
+                    },
+                    outputFormat: String(run.config.outputFormat),
+                    langs: (run.config.langs ?? []).map(toLangCode),
+                    inputDir: run.originalInput,
+                    outputDir: run.output,
+                    configHash: hashConfig(run.config),
+                    features: collectFeatures(run.config as Hash<unknown>),
+                    worker: {
+                        maxOldSpace:
+                            ((run.config as Hash<unknown>).workerMaxOldSpace as
+                                | number
+                                | undefined) ?? null,
+                    },
+                },
+                counters: {
+                    tocs: run.toc.tocs.length,
+                    entriesPlanned: run.toc.entries.length,
+                    entriesProcessed: this.entryCount,
+                    entriesByExtension: this.entriesByExtension,
+                    entriesByLang: this.entriesByLang,
+                    missed: countMissed(run),
+                    warnings: logCounts.warn,
+                    errors: logCounts.error,
+                },
+                output,
+            };
+
+            await run.write(join(run.output, STATS_FILENAME), JSON.stringify(stats, null, 2), true);
+        });
+    }
+
+    private reset() {
+        this.startedAt = 0;
+        this.firstEntryAt = 0;
+        this.lastEntryAt = 0;
+        this.entryCount = 0;
+        this.entriesByExtension = {};
+        this.entriesByLang = {};
+    }
+}
+
+function toLangCode(lang: string | {lang: string}): string {
+    return typeof lang === 'string' ? lang : lang.lang;
+}
+
+function collectFeatures(config: Hash<unknown>): string[] {
+    return KNOWN_FEATURE_FLAGS.filter((flag) => config[flag] === true);
+}
+
+function countMissed(run: Run): number {
+    let count = 0;
+    for (const node of run.entry.relations.overallOrder()) {
+        const data = run.entry.relations.getNodeData(node) as {type?: string} | undefined;
+        if (data?.type === 'missed') {
+            count++;
+        }
+    }
+    return count;
+}
+
+function stableStringify(value: unknown): string {
+    if (value === null || typeof value !== 'object') {
+        return JSON.stringify(value) ?? 'null';
+    }
+    if (Array.isArray(value)) {
+        return '[' + value.map(stableStringify).join(',') + ']';
+    }
+    const keys = Object.keys(value as object).sort();
+    return (
+        '{' +
+        keys
+            .map((k) => JSON.stringify(k) + ':' + stableStringify((value as Hash<unknown>)[k]))
+            .join(',') +
+        '}'
+    );
+}
+
+function hashConfig(config: unknown): string {
+    return createHash('sha256').update(stableStringify(config)).digest('hex').slice(0, 16);
+}
+
+async function readOutputSize(run: Run): Promise<OutputInfo> {
+    const files = await run.glob('**/*', {cwd: run.output});
+
+    let totalBytes = 0;
+    let largestFile: OutputInfo['largestFile'] = null;
+    const bytesByExtension: CountByKey = {};
+
+    await Promise.all(
+        files.map(async (file) => {
+            try {
+                const stat = await run.fs.stat(join(run.output, file));
+                const size = stat.size;
+
+                totalBytes += size;
+                if (!largestFile || size > largestFile.bytes) {
+                    largestFile = {path: file, bytes: size};
+                }
+                const ext = (extname(file) || '<noext>').toLowerCase();
+                bytesByExtension[ext] = (bytesByExtension[ext] ?? 0) + size;
+            } catch {
+                // File could be removed between glob and stat — silently skip.
+            }
+        }),
+    );
+
+    return {
+        files: files.length,
+        totalBytes,
+        bytesByExtension,
+        largestFile,
+    };
+}

--- a/src/commands/build/features/build-stats/index.ts
+++ b/src/commands/build/features/build-stats/index.ts
@@ -3,7 +3,6 @@ import type {Build, EntryInfo, Run} from '~/commands/build';
 
 import {extname, join} from 'node:path';
 import {arch, release as osRelease, platform} from 'node:os';
-import {createHash} from 'node:crypto';
 
 import {getHooks as getBaseHooks} from '~/core/program';
 import {getHooks as getBuildHooks} from '~/commands/build';
@@ -23,7 +22,6 @@ type OutputInfo = {
     files: number;
     totalBytes: number;
     bytesByExtension: CountByKey;
-    largestFile: {path: string; bytes: number} | null;
 };
 
 type BuildStatsFormat = {
@@ -53,8 +51,11 @@ type BuildStatsFormat = {
         langs: string[];
         inputDir: string;
         outputDir: string;
-        configHash: string;
         features: string[];
+        // process.memoryUsage().heapUsed snapshot at AfterAnyRun, in MB.
+        // Final snapshot, not a peak — but cheap and useful as a regression
+        // signal ("build started consuming 2x more memory").
+        memoryUsageMb: number;
         worker: {
             maxOldSpace: number | null;
         };
@@ -204,8 +205,8 @@ export class BuildStats {
                     langs: (run.config.langs ?? []).map(toLangCode),
                     inputDir: run.originalInput,
                     outputDir: run.output,
-                    configHash: hashConfig(run.config),
                     features: collectFeatures(run.config as Hash<unknown>),
+                    memoryUsageMb: Math.round(process.memoryUsage().heapUsed / 1024 / 1024),
                     worker: {
                         maxOldSpace:
                             ((run.config as Hash<unknown>).workerMaxOldSpace as
@@ -291,32 +292,10 @@ function collectGraph(run: Run): GraphCounters {
     return counters;
 }
 
-function stableStringify(value: unknown): string {
-    if (value === null || typeof value !== 'object') {
-        return JSON.stringify(value) ?? 'null';
-    }
-    if (Array.isArray(value)) {
-        return '[' + value.map(stableStringify).join(',') + ']';
-    }
-    const keys = Object.keys(value as object).sort();
-    return (
-        '{' +
-        keys
-            .map((k) => JSON.stringify(k) + ':' + stableStringify((value as Hash<unknown>)[k]))
-            .join(',') +
-        '}'
-    );
-}
-
-export function hashConfig(config: unknown): string {
-    return createHash('sha256').update(stableStringify(config)).digest('hex').slice(0, 16);
-}
-
 const EMPTY_OUTPUT: OutputInfo = {
     files: 0,
     totalBytes: 0,
     bytesByExtension: {},
-    largestFile: null,
 };
 
 async function readOutputSize(run: Run): Promise<OutputInfo> {
@@ -329,7 +308,6 @@ async function readOutputSize(run: Run): Promise<OutputInfo> {
     }
 
     let totalBytes = 0;
-    let largestFile: OutputInfo['largestFile'] = null;
     const bytesByExtension: CountByKey = {};
 
     await Promise.all(
@@ -339,9 +317,6 @@ async function readOutputSize(run: Run): Promise<OutputInfo> {
                 const size = stat.size;
 
                 totalBytes += size;
-                if (!largestFile || size > largestFile.bytes) {
-                    largestFile = {path: file, bytes: size};
-                }
                 const ext = (extname(file) || '<noext>').toLowerCase();
                 bytesByExtension[ext] = (bytesByExtension[ext] ?? 0) + size;
             } catch {
@@ -354,6 +329,5 @@ async function readOutputSize(run: Run): Promise<OutputInfo> {
         files: files.length,
         totalBytes,
         bytesByExtension,
-        largestFile,
     };
 }

--- a/src/commands/build/features/build-stats/index.ts
+++ b/src/commands/build/features/build-stats/index.ts
@@ -8,7 +8,7 @@ import {getHooks as getBaseHooks} from '~/core/program';
 import {getHooks as getBuildHooks} from '~/commands/build';
 import {valuable} from '~/core/config';
 import {VERSION} from '~/constants';
-import {stats as loggerStats} from '~/core/logger';
+import {getHooks as getLoggerHooks, stats as loggerStats} from '~/core/logger';
 import {langFromPath} from '~/core/utils';
 
 import {options} from './config';
@@ -85,9 +85,17 @@ type BuildStatsFormat = {
         };
         warnings: number;
         errors: number;
+        // Per-code breakdown of logged warnings/errors. Codes look like
+        // `YFM\d+` (e.g. YFM013, YFM017); messages without a recognizable
+        // code go into the `(uncoded)` bucket.
+        warningsByCode: CountByKey;
+        errorsByCode: CountByKey;
     };
     output: OutputInfo;
 };
+
+const CODE_RE = /\bYFM\d+\b/;
+const UNCODED = '(uncoded)';
 
 export type BuildStatsArgs = {
     buildStats: boolean;
@@ -113,6 +121,10 @@ export class BuildStats {
     private headings = 0;
 
     private contentBytes = 0;
+
+    private warningsByCode: CountByKey = {};
+
+    private errorsByCode: CountByKey = {};
 
     apply(program: Build) {
         getBaseHooks(program).Command.tap('BuildStats', (command: Command) => {
@@ -142,6 +154,14 @@ export class BuildStats {
 
             this.reset();
             this.startedAt = Date.now();
+
+            const loggerHooks = getLoggerHooks(run.logger);
+            loggerHooks.Warn.tap('BuildStats', (message) => {
+                this.bucketByCode(this.warningsByCode, message);
+            });
+            loggerHooks.Error.tap('BuildStats', (message) => {
+                this.bucketByCode(this.errorsByCode, message);
+            });
         });
 
         const onEntry = (run: Run, entry: NormalizedPath, info: DeepFrozen<EntryInfo>) => {
@@ -225,6 +245,8 @@ export class BuildStats {
                     graph: collectGraph(run),
                     warnings: logCounts.warn,
                     errors: logCounts.error,
+                    warningsByCode: this.warningsByCode,
+                    errorsByCode: this.errorsByCode,
                 },
                 output,
             };
@@ -242,6 +264,14 @@ export class BuildStats {
         this.entriesByLang = {};
         this.headings = 0;
         this.contentBytes = 0;
+        this.warningsByCode = {};
+        this.errorsByCode = {};
+    }
+
+    private bucketByCode(target: CountByKey, message: string) {
+        const match = message.match(CODE_RE);
+        const code = match ? match[0] : UNCODED;
+        target[code] = (target[code] ?? 0) + 1;
     }
 }
 

--- a/src/commands/build/features/build-stats/index.ts
+++ b/src/commands/build/features/build-stats/index.ts
@@ -3,6 +3,7 @@ import type {Build, EntryInfo, Run} from '~/commands/build';
 
 import {extname, join} from 'node:path';
 import {arch, release as osRelease, platform} from 'node:os';
+import pmap from 'p-map';
 
 import {getHooks as getBaseHooks} from '~/core/program';
 import {getHooks as getBuildHooks} from '~/commands/build';
@@ -15,6 +16,7 @@ import {options} from './config';
 
 const STATS_FILENAME = 'yfm-build-stats.json';
 const SCHEMA_VERSION = 1;
+const STAT_CONCURRENCY = 30;
 
 type CountByKey = Record<string, number>;
 
@@ -186,7 +188,9 @@ export class BuildStats {
             // Markdown-only payload: leading (yaml) pages don't have headings/html.
             if (info.leading === false) {
                 this.headings += info.headings?.length ?? 0;
-                this.contentBytes += info.html?.length ?? 0;
+                // String.length is UTF-16 code units, not bytes — use UTF-8
+                // byte length to get a real "content size in bytes".
+                this.contentBytes += info.html ? Buffer.byteLength(info.html, 'utf8') : 0;
             }
         };
 
@@ -340,8 +344,11 @@ async function readOutputSize(run: Run): Promise<OutputInfo> {
     let totalBytes = 0;
     const bytesByExtension: CountByKey = {};
 
-    await Promise.all(
-        files.map(async (file) => {
+    // Bound concurrency so we don't open thousands of FDs at once and trip
+    // EMFILE on outputs with lots of files.
+    await pmap(
+        files,
+        async (file) => {
             try {
                 const stat = await run.fs.stat(join(run.output, file));
                 const size = stat.size;
@@ -352,7 +359,8 @@ async function readOutputSize(run: Run): Promise<OutputInfo> {
             } catch {
                 // File could be removed between glob and stat — silently skip.
             }
-        }),
+        },
+        {concurrency: STAT_CONCURRENCY},
     );
 
     return {

--- a/src/commands/build/index.spec.ts
+++ b/src/commands/build/index.spec.ts
@@ -673,6 +673,8 @@ describe('Build command', () => {
 
         testBooleanFlag('originAsInput', '--origin-as-input', false);
 
+        testBooleanFlag('buildStats', '--build-stats', false);
+
         testBooleanFlag('copyOnWrite', '--copy-on-write', true);
 
         test(

--- a/src/commands/build/index.ts
+++ b/src/commands/build/index.ts
@@ -34,6 +34,7 @@ import {SinglePage} from './features/singlepage';
 import {PdfPage} from './features/pdf-page';
 import {Lint} from './features/linter';
 import {BuildManifest} from './features/build-manifest';
+import {BuildStats} from './features/build-stats';
 import {CrawlerManifest} from './features/crawler-manifest';
 import {SkipHtml} from './features/skip-html';
 import {Changelogs} from './features/changelogs';
@@ -98,6 +99,8 @@ export class Build extends BaseProgram<BuildConfig, BuildArgs> {
     readonly linter = new Lint();
 
     readonly buildManifest = new BuildManifest();
+
+    readonly buildStats = new BuildStats();
 
     readonly crawlerManifest = new CrawlerManifest();
 
@@ -164,6 +167,7 @@ export class Build extends BaseProgram<BuildConfig, BuildArgs> {
         this.pdfPage,
         this.linter,
         this.buildManifest,
+        this.buildStats,
         this.crawlerManifest,
         this.changelogs,
         this.search,

--- a/src/commands/build/types.ts
+++ b/src/commands/build/types.ts
@@ -11,6 +11,7 @@ import type {SkipHtmlArgs, SkipHtmlConfig} from './features/skip-html';
 import type {LintArgs, LintConfig, LintRawConfig} from './features/linter';
 import type {OutputMdConfig, PreprocessConfig} from './features/output-md';
 import type {BuildManifestArgs, BuildManifestConfig} from './features/build-manifest';
+import type {BuildStatsArgs, BuildStatsConfig} from './features/build-stats';
 import type {CrawlerManifestArgs, CrawlerManifestConfig} from './features/crawler-manifest';
 import type {ChangelogsArgs, ChangelogsConfig} from './features/changelogs';
 import type {SearchArgs, SearchConfig, SearchRawConfig} from './features/search';
@@ -103,6 +104,7 @@ export type BuildArgs = ProgramArgs &
             SkipHtmlArgs &
             LintArgs &
             BuildManifestArgs &
+            BuildStatsArgs &
             CrawlerManifestArgs &
             PreprocessConfig &
             ChangelogsArgs &
@@ -145,6 +147,7 @@ export type BuildConfig = Config<
         SkipHtmlConfig &
         LintConfig &
         BuildManifestConfig &
+        BuildStatsConfig &
         CrawlerManifestConfig &
         OutputMdConfig &
         ChangelogsConfig &


### PR DESCRIPTION
## Summary
- Adds an opt-in `BuildStats` feature that writes `yfm-build-stats.json` next to other build artifacts when `--build-stats` is set (or `buildStats: true` in `.yfm`). Intended for CI dashboards and regression detection, not for the runtime to consume.
- Format-agnostic: hooks into `BeforeAnyRun` / `AfterAnyRun` and the build-scoped `Entry` hook for both `md` and `html`. When the flag is off the feature is fully inert.
- `build.configHash` is sha256 of a stably-serialized `run.config` and matches the cache-key input shape called out in the FileProducer RFC, so it can be reused once that lands.

## What gets recorded
- **`cli`** — `version`, `node`, `platform`, `arch`, `osRelease`
- **`build`** — `startedAt`, `finishedAt`, `durationMs`, and a coarse `phasesMs.{prepare, entries, finalize}` derived from `Entry`-hook timestamps (no new hooks); plus `outputFormat`, `langs`, `inputDir`, `outputDir`, `configHash`, `features` (every config field that resolved to literal `true`), `worker.maxOldSpace`
- **`counters`** — `tocs`, `entriesPlanned` vs `entriesProcessed`, `entriesByExtension`, `entriesByLang`, `missed` (walks `entry.relations` for nodes tagged `type: 'missed'`), `warnings`, `errors`
- **`output`** — `files`, `totalBytes`, `bytesByExtension`, `largestFile` via globbing the output dir; failures to glob/stat log a warning and don't fail the build

`schemaVersion: 1` is at the top level so the format can grow without breaking consumers.

## Out of scope
- Per-entry duration distribution (p50/p95/top-N slowest pages) — needs a hook signature change since the current `Entry` hook fires before the per-entry timing in `Build.processEntry` is computed.
- Precise per-phase timing (`prepareInput`/`prepareRun`/`sync`/`processToc`/`releaseRun`/`cleanup`) — phases are currently just `console.log` calls in `Build.action()`; needs either phase hooks or a `run.timer.mark()` API.
