### PR TITLE
feat(translate): add AI translation provider (Yandex AI Studio / OpenAI / OpenRouter / Anthropic)

### DIFF
--- a/src/commands/translate/__tests__/index.ts
+++ b/src/commands/translate/__tests__/index.ts
@@ -13,6 +13,7 @@ import {Extract} from '../commands/extract';
 var resolveConfig: Mock;
 
 vi.mock('../providers/yandex/provider');
+vi.mock('../providers/ai/provider');
 vi.mock('~/core/config', async (importOriginal) => {
     resolveConfig = vi.fn((_path, {defaults, fallback}) => {
         return defaults || fallback;

--- a/src/commands/translate/index.spec.ts
+++ b/src/commands/translate/index.spec.ts
@@ -12,7 +12,7 @@ describe('Translate command', () => {
             test(
                 'should fail on unknown provider',
                 '--provider unknown --folder 1',
-                `error: option '--provider <value>' argument 'unknown' is invalid. Allowed choices are yandex.`,
+                `error: option '--provider <value>' argument 'unknown' is invalid. Allowed choices are yandex, yandexgpt, openai, openrouter, anthropic.`,
             );
 
             test('should handle default', '--folder 1', {

--- a/src/commands/translate/index.spec.ts
+++ b/src/commands/translate/index.spec.ts
@@ -1,4 +1,5 @@
 import type {YandexTranslationConfig} from './providers/yandex';
+import type {AITranslationConfig} from './providers/ai';
 
 import {describe, expect, it, vi} from 'vitest';
 
@@ -310,6 +311,120 @@ describe('Translate command', () => {
                     timeout: 30000,
                 },
             );
+        });
+
+        describe('ai providers', () => {
+            describe('openai', () => {
+                const test = testConfig<AITranslationConfig>(
+                    '--source ru --target en --provider openai --auth sk-test',
+                );
+
+                test('should handle defaults', '', {
+                    provider: 'openai',
+                    model: 'gpt-4o-mini',
+                    promptMode: 'append',
+                    temperature: 0,
+                    maxOutputTokens: 4000,
+                    maxBatchTokens: 2000,
+                    maxConcurrency: 5,
+                    retry: 3,
+                    timeout: 60000,
+                    apiHeaders: {},
+                });
+
+                test(
+                    'should handle config values with priority over defaults',
+                    '',
+                    {
+                        temperature: 0.3,
+                        maxBatchTokens: 1000,
+                        promptMode: 'replace',
+                        timeout: 120000,
+                    },
+                    {
+                        temperature: 0.3,
+                        maxBatchTokens: 1000,
+                        promptMode: 'replace',
+                        timeout: 120000,
+                    },
+                );
+
+                test(
+                    'should handle args with priority over config',
+                    '--temperature 0.7 --max-batch-tokens 500',
+                    {
+                        temperature: 0.3,
+                        maxBatchTokens: 1000,
+                    },
+                    {
+                        temperature: 0.7,
+                        maxBatchTokens: 500,
+                    },
+                );
+
+                test('should handle api base arg', '--api-base https://llm.internal/v1', {
+                    apiBase: 'https://llm.internal/v1',
+                });
+
+                test(
+                    'should handle api base from config',
+                    '',
+                    {
+                        apiBase: 'https://llm.internal/v1',
+                    },
+                    {
+                        apiBase: 'https://llm.internal/v1',
+                    },
+                );
+
+                test('should parse api headers arg', '--api-header X-Org:team', {
+                    apiHeaders: {'X-Org': 'team'},
+                });
+
+                test(
+                    'should handle api headers object from config',
+                    '',
+                    {
+                        // @ts-ignore
+                        apiHeaders: {'X-Org': 'team'},
+                    },
+                    {
+                        apiHeaders: {'X-Org': 'team'},
+                    },
+                );
+
+                test('should clamp max concurrency to at least 1', '--max-concurrency 0', {
+                    maxConcurrency: 1,
+                });
+            });
+
+            describe('yandexgpt', () => {
+                const test = testConfig<AITranslationConfig>(
+                    '--source ru --target en --provider yandexgpt --auth y0_test',
+                );
+
+                it('should require folder for short model name', async () => {
+                    const instance = await run(
+                        '-o output --source ru --target en --provider yandexgpt --auth y0_test',
+                    );
+
+                    expect(instance.report.code).toBe(1);
+                    expect(instance.provider?.translate).not.toBeCalled();
+                });
+
+                test(
+                    'should allow qualified model uri without folder',
+                    '--model gpt://b1g/yandexgpt/latest',
+                    {
+                        model: 'gpt://b1g/yandexgpt/latest',
+                    },
+                );
+
+                test('should handle folder with short model name', '--folder b1g', {
+                    folder: 'b1g',
+                    model: 'yandexgpt-lite',
+                });
+            });
         });
 
         describe('yandex provider', () => {

--- a/src/commands/translate/index.ts
+++ b/src/commands/translate/index.ts
@@ -128,7 +128,9 @@ export class Translate extends BaseProgram<TranslateConfig, TranslateArgs> {
                 vars,
                 provider: defined('provider', args, config),
                 dryRun: defined('dryRun', args, config) || false,
-                timeout: (defined('timeout', args, config) as number) ?? 5000,
+                // No global default here: each provider applies its own
+                // (5s for yandex, 60s for LLM providers).
+                timeout: defined('timeout', args, config) as number,
             });
         });
     }

--- a/src/commands/translate/index.ts
+++ b/src/commands/translate/index.ts
@@ -19,6 +19,7 @@ import {DESCRIPTION, NAME, options} from './config';
 import {Extract} from './commands/extract';
 import {Compose} from './commands/compose';
 import {Extension as YandexTranslation} from './providers/yandex';
+import {Extension as AITranslation} from './providers/ai';
 import {resolveSource, resolveTargets, resolveVars} from './utils';
 import {Run} from './run';
 import {configDefaults} from './utils/config';
@@ -91,6 +92,7 @@ export class Translate extends BaseProgram<TranslateConfig, TranslateArgs> {
         this.extract,
         this.compose,
         new YandexTranslation(),
+        new AITranslation(),
         new ExtractOpenapiIncluderFakeExtension(),
     ];
 

--- a/src/commands/translate/providers/ai/auth.ts
+++ b/src/commands/translate/providers/ai/auth.ts
@@ -1,0 +1,40 @@
+import {existsSync, readFileSync} from 'node:fs';
+
+const YANDEX_BEARER_PREFIXES = ['y0_', 't1.'];
+const YANDEX_API_KEY_PREFIX = 'AQVN';
+
+/**
+ * Resolves an auth token from a CLI value.
+ * The value may be either the raw token or a path to a file containing the token.
+ */
+export function resolveToken(value: string): string {
+    if (!value) {
+        throw new Error('No auth token provided');
+    }
+
+    const trimmed = value.trim();
+
+    if (existsSync(trimmed)) {
+        return readFileSync(trimmed, 'utf8').trim();
+    }
+
+    return trimmed;
+}
+
+/**
+ * Builds an Authorization header value for Yandex AI Studio.
+ * Supports IAM/OAuth tokens (Bearer) and service-account API keys (Api-Key).
+ */
+export function yandexAuthHeader(token: string): string {
+    for (const prefix of YANDEX_BEARER_PREFIXES) {
+        if (token.startsWith(prefix)) {
+            return 'Bearer ' + token;
+        }
+    }
+
+    if (token.startsWith(YANDEX_API_KEY_PREFIX)) {
+        return 'Api-Key ' + token;
+    }
+
+    return 'Api-Key ' + token;
+}

--- a/src/commands/translate/providers/ai/auth.ts
+++ b/src/commands/translate/providers/ai/auth.ts
@@ -1,7 +1,6 @@
 import {existsSync, readFileSync} from 'node:fs';
 
 const YANDEX_BEARER_PREFIXES = ['y0_', 't1.'];
-const YANDEX_API_KEY_PREFIX = 'AQVN';
 
 /**
  * Resolves an auth token from a CLI value.
@@ -30,10 +29,6 @@ export function yandexAuthHeader(token: string): string {
         if (token.startsWith(prefix)) {
             return 'Bearer ' + token;
         }
-    }
-
-    if (token.startsWith(YANDEX_API_KEY_PREFIX)) {
-        return 'Api-Key ' + token;
     }
 
     return 'Api-Key ' + token;

--- a/src/commands/translate/providers/ai/clients/anthropic.ts
+++ b/src/commands/translate/providers/ai/clients/anthropic.ts
@@ -1,0 +1,109 @@
+import type {ChatMessage, CompletionOptions, CompletionResult, LLMClient} from './types';
+
+import axios, {AxiosError} from 'axios';
+
+import {LLMAuthError, LLMRateLimitError, LLMRequestError, LLMResponseError} from '../utils';
+
+const DEFAULT_BASE_URL = 'https://api.anthropic.com/v1';
+const ANTHROPIC_VERSION = '2023-06-01';
+
+type AnthropicMessagesResponse = {
+    content: {type: string; text?: string}[];
+    stop_reason: string;
+    usage?: {
+        input_tokens?: number;
+        output_tokens?: number;
+    };
+};
+
+export type AnthropicClientOptions = {
+    token: string;
+    model: string;
+    baseUrl?: string;
+    timeout?: number;
+};
+
+export class AnthropicClient implements LLMClient {
+    readonly name = 'anthropic';
+
+    private readonly token: string;
+    private readonly model: string;
+    private readonly baseUrl: string;
+    private readonly timeout: number;
+
+    constructor(options: AnthropicClientOptions) {
+        this.token = options.token;
+        this.model = options.model;
+        this.baseUrl = (options.baseUrl || DEFAULT_BASE_URL).replace(/\/$/, '');
+        this.timeout = options.timeout ?? 60_000;
+    }
+
+    async complete(
+        messages: ChatMessage[],
+        options: CompletionOptions,
+    ): Promise<CompletionResult> {
+        const system = messages
+            .filter((m) => m.role === 'system')
+            .map((m) => m.content)
+            .join('\n\n');
+        const conversation = messages
+            .filter((m) => m.role !== 'system')
+            .map((m) => ({role: m.role, content: m.content}));
+
+        try {
+            const {data} = await axios.post<AnthropicMessagesResponse>(
+                `${this.baseUrl}/messages`,
+                {
+                    model: this.model,
+                    system: system || undefined,
+                    messages: conversation,
+                    temperature: options.temperature,
+                    max_tokens: options.maxTokens,
+                },
+                {
+                    timeout: this.timeout,
+                    headers: {
+                        'x-api-key': this.token,
+                        'anthropic-version': ANTHROPIC_VERSION,
+                        'Content-Type': 'application/json',
+                        'User-Agent': 'github.com/diplodoc-platform/cli',
+                    },
+                },
+            );
+
+            const text = data.content
+                .filter((block) => block.type === 'text' && block.text)
+                .map((block) => block.text as string)
+                .join('');
+
+            if (!text) {
+                throw new LLMResponseError('Anthropic returned an empty response');
+            }
+
+            return {
+                text,
+                usage: {
+                    inputTokens: data.usage?.input_tokens ?? 0,
+                    outputTokens: data.usage?.output_tokens ?? 0,
+                },
+            };
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+            if (error instanceof AxiosError && error.response) {
+                const {status, statusText, data} = error.response;
+                const message = data?.error?.message || data?.message || statusText;
+
+                if (status === 401 || status === 403) {
+                    throw new LLMAuthError(`Anthropic auth failed: ${message}`);
+                }
+                if (status === 429) {
+                    throw new LLMRateLimitError(message);
+                }
+                throw new LLMRequestError(status, message, {
+                    retryable: status >= 500 && status < 600,
+                });
+            }
+            throw error;
+        }
+    }
+}

--- a/src/commands/translate/providers/ai/clients/anthropic.ts
+++ b/src/commands/translate/providers/ai/clients/anthropic.ts
@@ -1,8 +1,8 @@
 import type {ChatMessage, CompletionOptions, CompletionResult, LLMClient} from './types';
 
-import axios, {AxiosError} from 'axios';
+import axios from 'axios';
 
-import {LLMAuthError, LLMRateLimitError, LLMRequestError, LLMResponseError} from '../utils';
+import {LLMResponseError, throwLLMError} from '../utils';
 
 const DEFAULT_BASE_URL = 'https://api.anthropic.com/v1';
 const ANTHROPIC_VERSION = '2023-06-01';
@@ -38,10 +38,7 @@ export class AnthropicClient implements LLMClient {
         this.timeout = options.timeout ?? 60_000;
     }
 
-    async complete(
-        messages: ChatMessage[],
-        options: CompletionOptions,
-    ): Promise<CompletionResult> {
+    async complete(messages: ChatMessage[], options: CompletionOptions): Promise<CompletionResult> {
         const system = messages
             .filter((m) => m.role === 'system')
             .map((m) => m.content)
@@ -87,23 +84,8 @@ export class AnthropicClient implements LLMClient {
                     outputTokens: data.usage?.output_tokens ?? 0,
                 },
             };
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (error: any) {
-            if (error instanceof AxiosError && error.response) {
-                const {status, statusText, data} = error.response;
-                const message = data?.error?.message || data?.message || statusText;
-
-                if (status === 401 || status === 403) {
-                    throw new LLMAuthError(`Anthropic auth failed: ${message}`);
-                }
-                if (status === 429) {
-                    throw new LLMRateLimitError(message);
-                }
-                throw new LLMRequestError(status, message, {
-                    retryable: status >= 500 && status < 600,
-                });
-            }
-            throw error;
+        } catch (error) {
+            throwLLMError(error, 'Anthropic');
         }
     }
 }

--- a/src/commands/translate/providers/ai/clients/anthropic.ts
+++ b/src/commands/translate/providers/ai/clients/anthropic.ts
@@ -21,6 +21,7 @@ export type AnthropicClientOptions = {
     model: string;
     baseUrl?: string;
     timeout?: number;
+    headers?: Record<string, string>;
 };
 
 export class AnthropicClient implements LLMClient {
@@ -30,12 +31,14 @@ export class AnthropicClient implements LLMClient {
     private readonly model: string;
     private readonly baseUrl: string;
     private readonly timeout: number;
+    private readonly headers: Record<string, string>;
 
     constructor(options: AnthropicClientOptions) {
         this.token = options.token;
         this.model = options.model;
         this.baseUrl = (options.baseUrl || DEFAULT_BASE_URL).replace(/\/$/, '');
         this.timeout = options.timeout ?? 60_000;
+        this.headers = options.headers || {};
     }
 
     async complete(messages: ChatMessage[], options: CompletionOptions): Promise<CompletionResult> {
@@ -64,9 +67,18 @@ export class AnthropicClient implements LLMClient {
                         'anthropic-version': ANTHROPIC_VERSION,
                         'Content-Type': 'application/json',
                         'User-Agent': 'github.com/diplodoc-platform/cli',
+                        ...this.headers,
                     },
                 },
             );
+
+            if (data.stop_reason === 'max_tokens') {
+                throw new LLMResponseError(
+                    'Anthropic response was truncated (stop_reason=max_tokens). ' +
+                        'Increase --max-output-tokens or reduce --max-batch-tokens.',
+                    false,
+                );
+            }
 
             const text = data.content
                 .filter((block) => block.type === 'text' && block.text)

--- a/src/commands/translate/providers/ai/clients/clients.spec.ts
+++ b/src/commands/translate/providers/ai/clients/clients.spec.ts
@@ -1,0 +1,260 @@
+import type {Mock} from 'vitest';
+
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import axios from 'axios';
+
+import {LLMResponseError} from '../utils';
+
+import {AnthropicClient} from './anthropic';
+import {createOpenAIClient, createOpenRouterClient} from './openai';
+import {YandexGptClient} from './yandexgpt';
+
+vi.mock('axios', async (importOriginal) => {
+    const actual = (await importOriginal()) as {default: object};
+
+    return {
+        ...actual,
+        default: {
+            ...actual.default,
+            post: vi.fn(),
+        },
+    };
+});
+
+const post = axios.post as Mock;
+
+const messages = [
+    {role: 'system' as const, content: 'system'},
+    {role: 'user' as const, content: 'user'},
+];
+
+const completionOptions = {temperature: 0, maxTokens: 100};
+
+describe('translate ai clients', () => {
+    beforeEach(() => {
+        post.mockReset();
+    });
+
+    describe('openai', () => {
+        const response = {
+            choices: [{message: {role: 'assistant', content: 'result'}, finish_reason: 'stop'}],
+            usage: {prompt_tokens: 10, completion_tokens: 20},
+        };
+
+        it('should request chat completions with max_completion_tokens', async () => {
+            post.mockResolvedValueOnce({data: response});
+
+            const client = createOpenAIClient({token: 't', model: 'gpt-4o-mini'});
+            const result = await client.complete(messages, completionOptions);
+
+            expect(result.text).toBe('result');
+            expect(result.usage).toEqual({inputTokens: 10, outputTokens: 20});
+
+            const [url, payload] = post.mock.calls[0];
+            expect(url).toBe('https://api.openai.com/v1/chat/completions');
+            expect(payload.max_completion_tokens).toBe(100);
+            expect(payload.max_tokens).toBeUndefined();
+        });
+
+        it('should respect custom base url and headers', async () => {
+            post.mockResolvedValueOnce({data: response});
+
+            const client = createOpenAIClient({
+                token: 't',
+                model: 'internal-model',
+                baseUrl: 'https://llm.internal/v1/',
+                headers: {'X-Org': 'team'},
+            });
+            await client.complete(messages, completionOptions);
+
+            const [url, , config] = post.mock.calls[0];
+            expect(url).toBe('https://llm.internal/v1/chat/completions');
+            expect(config.headers['X-Org']).toBe('team');
+            expect(config.headers.Authorization).toBe('Bearer t');
+        });
+
+        it('should throw on truncated response', async () => {
+            post.mockResolvedValueOnce({
+                data: {
+                    choices: [
+                        {message: {role: 'assistant', content: 'part'}, finish_reason: 'length'},
+                    ],
+                },
+            });
+
+            const client = createOpenAIClient({token: 't', model: 'gpt-4o-mini'});
+
+            await expect(client.complete(messages, completionOptions)).rejects.toThrow(
+                LLMResponseError,
+            );
+        });
+
+        it('should throw on empty response', async () => {
+            post.mockResolvedValueOnce({data: {choices: []}});
+
+            const client = createOpenAIClient({token: 't', model: 'gpt-4o-mini'});
+
+            await expect(client.complete(messages, completionOptions)).rejects.toThrow(
+                'empty response',
+            );
+        });
+    });
+
+    describe('openrouter', () => {
+        it('should keep max_tokens for compatible gateways', async () => {
+            post.mockResolvedValueOnce({
+                data: {
+                    choices: [
+                        {message: {role: 'assistant', content: 'result'}, finish_reason: 'stop'},
+                    ],
+                },
+            });
+
+            const client = createOpenRouterClient({token: 't', model: 'openai/gpt-4o-mini'});
+            await client.complete(messages, completionOptions);
+
+            const [url, payload, config] = post.mock.calls[0];
+            expect(url).toBe('https://openrouter.ai/api/v1/chat/completions');
+            expect(payload.max_tokens).toBe(100);
+            expect(payload.max_completion_tokens).toBeUndefined();
+            expect(config.headers['HTTP-Referer']).toBeDefined();
+        });
+    });
+
+    describe('anthropic', () => {
+        it('should join text blocks and pass system prompt separately', async () => {
+            post.mockResolvedValueOnce({
+                data: {
+                    content: [
+                        {type: 'text', text: 'One'},
+                        {type: 'text', text: 'Two'},
+                    ],
+                    stop_reason: 'end_turn',
+                    usage: {input_tokens: 5, output_tokens: 6},
+                },
+            });
+
+            const client = new AnthropicClient({token: 't', model: 'claude-sonnet-4-5'});
+            const result = await client.complete(messages, completionOptions);
+
+            expect(result.text).toBe('OneTwo');
+
+            const [url, payload, config] = post.mock.calls[0];
+            expect(url).toBe('https://api.anthropic.com/v1/messages');
+            expect(payload.system).toBe('system');
+            expect(payload.messages).toEqual([{role: 'user', content: 'user'}]);
+            expect(config.headers['x-api-key']).toBe('t');
+        });
+
+        it('should allow header overrides for internal gateways', async () => {
+            post.mockResolvedValueOnce({
+                data: {content: [{type: 'text', text: 'ok'}], stop_reason: 'end_turn'},
+            });
+
+            const client = new AnthropicClient({
+                token: 't',
+                model: 'claude-sonnet-4-5',
+                baseUrl: 'https://llm.internal/v1',
+                headers: {Authorization: 'OAuth session'},
+            });
+            await client.complete(messages, completionOptions);
+
+            const [url, , config] = post.mock.calls[0];
+            expect(url).toBe('https://llm.internal/v1/messages');
+            expect(config.headers.Authorization).toBe('OAuth session');
+        });
+
+        it('should throw on truncated response', async () => {
+            post.mockResolvedValueOnce({
+                data: {content: [{type: 'text', text: 'part'}], stop_reason: 'max_tokens'},
+            });
+
+            const client = new AnthropicClient({token: 't', model: 'claude-sonnet-4-5'});
+
+            await expect(client.complete(messages, completionOptions)).rejects.toThrow('truncated');
+        });
+    });
+
+    describe('yandexgpt', () => {
+        const response = {
+            result: {
+                alternatives: [
+                    {
+                        message: {role: 'assistant', text: 'result'},
+                        status: 'ALTERNATIVE_STATUS_FINAL',
+                    },
+                ],
+                usage: {inputTextTokens: '10', completionTokens: '20'},
+            },
+        };
+
+        it('should post to the default completion endpoint', async () => {
+            post.mockResolvedValueOnce({data: response});
+
+            const client = new YandexGptClient({token: 'y0_t', model: 'yandexgpt', folder: 'b1g'});
+            const result = await client.complete(messages, completionOptions);
+
+            expect(result.text).toBe('result');
+            expect(result.usage).toEqual({inputTokens: 10, outputTokens: 20});
+
+            const [url, payload] = post.mock.calls[0];
+            expect(url).toBe('https://llm.api.cloud.yandex.net/foundationModels/v1/completion');
+            expect(payload.modelUri).toBe('gpt://b1g/yandexgpt/latest');
+        });
+
+        it('should append the completion path to a custom base url', async () => {
+            post.mockResolvedValueOnce({data: response});
+
+            const client = new YandexGptClient({
+                token: 'y0_t',
+                model: 'yandexgpt',
+                folder: 'b1g',
+                baseUrl: 'https://llm.internal/',
+            });
+            await client.complete(messages, completionOptions);
+
+            const [url] = post.mock.calls[0];
+            expect(url).toBe('https://llm.internal/foundationModels/v1/completion');
+        });
+
+        it('should throw on truncated response', async () => {
+            post.mockResolvedValueOnce({
+                data: {
+                    result: {
+                        alternatives: [
+                            {
+                                message: {role: 'assistant', text: 'part'},
+                                status: 'ALTERNATIVE_STATUS_TRUNCATED_FINAL',
+                            },
+                        ],
+                    },
+                },
+            });
+
+            const client = new YandexGptClient({token: 'y0_t', model: 'yandexgpt', folder: 'b1g'});
+
+            await expect(client.complete(messages, completionOptions)).rejects.toThrow('truncated');
+        });
+
+        it('should throw on content filter rejection', async () => {
+            post.mockResolvedValueOnce({
+                data: {
+                    result: {
+                        alternatives: [
+                            {
+                                message: {role: 'assistant', text: ''},
+                                status: 'ALTERNATIVE_STATUS_CONTENT_FILTER',
+                            },
+                        ],
+                    },
+                },
+            });
+
+            const client = new YandexGptClient({token: 'y0_t', model: 'yandexgpt', folder: 'b1g'});
+
+            await expect(client.complete(messages, completionOptions)).rejects.toThrow(
+                'content filter',
+            );
+        });
+    });
+});

--- a/src/commands/translate/providers/ai/clients/openai.ts
+++ b/src/commands/translate/providers/ai/clients/openai.ts
@@ -1,0 +1,129 @@
+import type {ChatMessage, CompletionOptions, CompletionResult, LLMClient} from './types';
+
+import axios, {AxiosError} from 'axios';
+
+import {LLMAuthError, LLMRateLimitError, LLMRequestError, LLMResponseError} from '../utils';
+
+const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
+const DEFAULT_OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+
+type OpenAIChatResponse = {
+    choices: {
+        message: {role: string; content: string};
+        finish_reason: string;
+    }[];
+    usage?: {
+        prompt_tokens?: number;
+        completion_tokens?: number;
+        total_tokens?: number;
+    };
+};
+
+export type OpenAICompatibleClientOptions = {
+    token: string;
+    model: string;
+    baseUrl?: string;
+    timeout?: number;
+    extraHeaders?: Record<string, string>;
+    name?: string;
+};
+
+export class OpenAICompatibleClient implements LLMClient {
+    readonly name: string;
+
+    private readonly token: string;
+    private readonly model: string;
+    private readonly baseUrl: string;
+    private readonly timeout: number;
+    private readonly extraHeaders: Record<string, string>;
+
+    constructor(options: OpenAICompatibleClientOptions) {
+        this.name = options.name || 'openai';
+        this.token = options.token;
+        this.model = options.model;
+        this.baseUrl = (options.baseUrl || DEFAULT_OPENAI_BASE_URL).replace(/\/$/, '');
+        this.timeout = options.timeout ?? 60_000;
+        this.extraHeaders = options.extraHeaders || {};
+    }
+
+    async complete(
+        messages: ChatMessage[],
+        options: CompletionOptions,
+    ): Promise<CompletionResult> {
+        try {
+            const {data} = await axios.post<OpenAIChatResponse>(
+                `${this.baseUrl}/chat/completions`,
+                {
+                    model: this.model,
+                    messages: messages.map((m) => ({role: m.role, content: m.content})),
+                    temperature: options.temperature,
+                    max_tokens: options.maxTokens,
+                },
+                {
+                    timeout: this.timeout,
+                    headers: {
+                        Authorization: `Bearer ${this.token}`,
+                        'Content-Type': 'application/json',
+                        'User-Agent': 'github.com/diplodoc-platform/cli',
+                        ...this.extraHeaders,
+                    },
+                },
+            );
+
+            const choice = data.choices?.[0];
+            if (!choice) {
+                throw new LLMResponseError(`${this.name} returned no choices`);
+            }
+
+            return {
+                text: choice.message.content,
+                usage: {
+                    inputTokens: data.usage?.prompt_tokens ?? 0,
+                    outputTokens: data.usage?.completion_tokens ?? 0,
+                },
+            };
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+            if (error instanceof AxiosError && error.response) {
+                const {status, statusText, data} = error.response;
+                const message = data?.error?.message || data?.message || statusText;
+
+                if (status === 401 || status === 403) {
+                    throw new LLMAuthError(`${this.name} auth failed: ${message}`);
+                }
+                if (status === 429) {
+                    throw new LLMRateLimitError(message);
+                }
+                throw new LLMRequestError(status, message, {
+                    retryable: status >= 500 && status < 600,
+                });
+            }
+            throw error;
+        }
+    }
+}
+
+export function createOpenAIClient(opts: Omit<OpenAICompatibleClientOptions, 'name' | 'baseUrl'> & {
+    baseUrl?: string;
+}) {
+    return new OpenAICompatibleClient({
+        ...opts,
+        name: 'openai',
+        baseUrl: opts.baseUrl || DEFAULT_OPENAI_BASE_URL,
+    });
+}
+
+export function createOpenRouterClient(
+    opts: Omit<OpenAICompatibleClientOptions, 'name' | 'baseUrl'> & {baseUrl?: string},
+) {
+    return new OpenAICompatibleClient({
+        ...opts,
+        name: 'openrouter',
+        baseUrl: opts.baseUrl || DEFAULT_OPENROUTER_BASE_URL,
+        extraHeaders: {
+            'HTTP-Referer': 'https://github.com/diplodoc-platform/cli',
+            'X-Title': 'Diplodoc CLI',
+            ...(opts.extraHeaders || {}),
+        },
+    });
+}

--- a/src/commands/translate/providers/ai/clients/openai.ts
+++ b/src/commands/translate/providers/ai/clients/openai.ts
@@ -1,8 +1,8 @@
 import type {ChatMessage, CompletionOptions, CompletionResult, LLMClient} from './types';
 
-import axios, {AxiosError} from 'axios';
+import axios from 'axios';
 
-import {LLMAuthError, LLMRateLimitError, LLMRequestError, LLMResponseError} from '../utils';
+import {LLMResponseError, throwLLMError} from '../utils';
 
 const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
 const DEFAULT_OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
@@ -46,10 +46,7 @@ export class OpenAICompatibleClient implements LLMClient {
         this.extraHeaders = options.extraHeaders || {};
     }
 
-    async complete(
-        messages: ChatMessage[],
-        options: CompletionOptions,
-    ): Promise<CompletionResult> {
+    async complete(messages: ChatMessage[], options: CompletionOptions): Promise<CompletionResult> {
         try {
             const {data} = await axios.post<OpenAIChatResponse>(
                 `${this.baseUrl}/chat/completions`,
@@ -70,42 +67,29 @@ export class OpenAICompatibleClient implements LLMClient {
                 },
             );
 
-            const choice = data.choices?.[0];
-            if (!choice) {
-                throw new LLMResponseError(`${this.name} returned no choices`);
+            const text = data.choices?.[0]?.message?.content;
+            if (!text) {
+                throw new LLMResponseError(`${this.name} returned an empty response`);
             }
 
             return {
-                text: choice.message.content,
+                text,
                 usage: {
                     inputTokens: data.usage?.prompt_tokens ?? 0,
                     outputTokens: data.usage?.completion_tokens ?? 0,
                 },
             };
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (error: any) {
-            if (error instanceof AxiosError && error.response) {
-                const {status, statusText, data} = error.response;
-                const message = data?.error?.message || data?.message || statusText;
-
-                if (status === 401 || status === 403) {
-                    throw new LLMAuthError(`${this.name} auth failed: ${message}`);
-                }
-                if (status === 429) {
-                    throw new LLMRateLimitError(message);
-                }
-                throw new LLMRequestError(status, message, {
-                    retryable: status >= 500 && status < 600,
-                });
-            }
-            throw error;
+        } catch (error) {
+            throwLLMError(error, this.name);
         }
     }
 }
 
-export function createOpenAIClient(opts: Omit<OpenAICompatibleClientOptions, 'name' | 'baseUrl'> & {
-    baseUrl?: string;
-}) {
+export function createOpenAIClient(
+    opts: Omit<OpenAICompatibleClientOptions, 'name' | 'baseUrl'> & {
+        baseUrl?: string;
+    },
+) {
     return new OpenAICompatibleClient({
         ...opts,
         name: 'openai',

--- a/src/commands/translate/providers/ai/clients/openai.ts
+++ b/src/commands/translate/providers/ai/clients/openai.ts
@@ -121,7 +121,7 @@ export function createOpenRouterClient(
         headers: {
             'HTTP-Referer': 'https://github.com/diplodoc-platform/cli',
             'X-Title': 'Diplodoc CLI',
-            ...(opts.headers || {}),
+            ...opts.headers,
         },
     });
 }

--- a/src/commands/translate/providers/ai/clients/openai.ts
+++ b/src/commands/translate/providers/ai/clients/openai.ts
@@ -24,8 +24,11 @@ export type OpenAICompatibleClientOptions = {
     model: string;
     baseUrl?: string;
     timeout?: number;
-    extraHeaders?: Record<string, string>;
+    headers?: Record<string, string>;
     name?: string;
+    // OpenAI deprecated max_tokens in favor of max_completion_tokens,
+    // but most compatible gateways still expect max_tokens.
+    tokenParam?: 'max_tokens' | 'max_completion_tokens';
 };
 
 export class OpenAICompatibleClient implements LLMClient {
@@ -35,7 +38,8 @@ export class OpenAICompatibleClient implements LLMClient {
     private readonly model: string;
     private readonly baseUrl: string;
     private readonly timeout: number;
-    private readonly extraHeaders: Record<string, string>;
+    private readonly headers: Record<string, string>;
+    private readonly tokenParam: 'max_tokens' | 'max_completion_tokens';
 
     constructor(options: OpenAICompatibleClientOptions) {
         this.name = options.name || 'openai';
@@ -43,7 +47,8 @@ export class OpenAICompatibleClient implements LLMClient {
         this.model = options.model;
         this.baseUrl = (options.baseUrl || DEFAULT_OPENAI_BASE_URL).replace(/\/$/, '');
         this.timeout = options.timeout ?? 60_000;
-        this.extraHeaders = options.extraHeaders || {};
+        this.headers = options.headers || {};
+        this.tokenParam = options.tokenParam || 'max_tokens';
     }
 
     async complete(messages: ChatMessage[], options: CompletionOptions): Promise<CompletionResult> {
@@ -54,7 +59,7 @@ export class OpenAICompatibleClient implements LLMClient {
                     model: this.model,
                     messages: messages.map((m) => ({role: m.role, content: m.content})),
                     temperature: options.temperature,
-                    max_tokens: options.maxTokens,
+                    [this.tokenParam]: options.maxTokens,
                 },
                 {
                     timeout: this.timeout,
@@ -62,12 +67,22 @@ export class OpenAICompatibleClient implements LLMClient {
                         Authorization: `Bearer ${this.token}`,
                         'Content-Type': 'application/json',
                         'User-Agent': 'github.com/diplodoc-platform/cli',
-                        ...this.extraHeaders,
+                        ...this.headers,
                     },
                 },
             );
 
-            const text = data.choices?.[0]?.message?.content;
+            const choice = data.choices?.[0];
+
+            if (choice?.finish_reason === 'length') {
+                throw new LLMResponseError(
+                    `${this.name} response was truncated (finish_reason=length). ` +
+                        'Increase --max-output-tokens or reduce --max-batch-tokens.',
+                    false,
+                );
+            }
+
+            const text = choice?.message?.content;
             if (!text) {
                 throw new LLMResponseError(`${this.name} returned an empty response`);
             }
@@ -86,28 +101,27 @@ export class OpenAICompatibleClient implements LLMClient {
 }
 
 export function createOpenAIClient(
-    opts: Omit<OpenAICompatibleClientOptions, 'name' | 'baseUrl'> & {
-        baseUrl?: string;
-    },
+    opts: Omit<OpenAICompatibleClientOptions, 'name' | 'tokenParam'>,
 ) {
     return new OpenAICompatibleClient({
         ...opts,
         name: 'openai',
         baseUrl: opts.baseUrl || DEFAULT_OPENAI_BASE_URL,
+        tokenParam: 'max_completion_tokens',
     });
 }
 
 export function createOpenRouterClient(
-    opts: Omit<OpenAICompatibleClientOptions, 'name' | 'baseUrl'> & {baseUrl?: string},
+    opts: Omit<OpenAICompatibleClientOptions, 'name' | 'tokenParam'>,
 ) {
     return new OpenAICompatibleClient({
         ...opts,
         name: 'openrouter',
         baseUrl: opts.baseUrl || DEFAULT_OPENROUTER_BASE_URL,
-        extraHeaders: {
+        headers: {
             'HTTP-Referer': 'https://github.com/diplodoc-platform/cli',
             'X-Title': 'Diplodoc CLI',
-            ...(opts.extraHeaders || {}),
+            ...(opts.headers || {}),
         },
     });
 }

--- a/src/commands/translate/providers/ai/clients/types.ts
+++ b/src/commands/translate/providers/ai/clients/types.ts
@@ -1,0 +1,26 @@
+export type ChatRole = 'system' | 'user' | 'assistant';
+
+export type ChatMessage = {
+    role: ChatRole;
+    content: string;
+};
+
+export type CompletionOptions = {
+    temperature: number;
+    maxTokens: number;
+};
+
+export type CompletionUsage = {
+    inputTokens: number;
+    outputTokens: number;
+};
+
+export type CompletionResult = {
+    text: string;
+    usage?: CompletionUsage;
+};
+
+export interface LLMClient {
+    readonly name: string;
+    complete(messages: ChatMessage[], options: CompletionOptions): Promise<CompletionResult>;
+}

--- a/src/commands/translate/providers/ai/clients/yandexgpt.ts
+++ b/src/commands/translate/providers/ai/clients/yandexgpt.ts
@@ -1,0 +1,148 @@
+import type {ChatMessage, CompletionOptions, CompletionResult, LLMClient} from './types';
+
+import axios, {AxiosError} from 'axios';
+
+import {LLMAuthError, LLMRateLimitError, LLMRequestError, LLMResponseError} from '../utils';
+import {yandexAuthHeader} from '../auth';
+
+const DEFAULT_ENDPOINT = 'https://llm.api.cloud.yandex.net/foundationModels/v1/completion';
+
+type YandexMessage = {
+    role: 'system' | 'user' | 'assistant';
+    text: string;
+};
+
+type YandexCompletionResponse = {
+    result: {
+        alternatives: {
+            message: {role: string; text: string};
+            status: string;
+        }[];
+        usage?: {
+            inputTextTokens?: string | number;
+            completionTokens?: string | number;
+            totalTokens?: string | number;
+        };
+        modelVersion?: string;
+    };
+};
+
+export type YandexGptClientOptions = {
+    token: string;
+    folder: string;
+    model: string;
+    endpoint?: string;
+    timeout?: number;
+};
+
+/**
+ * Resolves a `gpt://` URI for Yandex AI Studio.
+ * Accepts either a short model name (e.g. `yandexgpt-lite`, folder taken from options)
+ * or a fully qualified URI (e.g. `gpt://b1g.../yandexgpt-lite/latest`).
+ */
+function resolveModelUri(model: string, folder: string): string {
+    if (model.startsWith('gpt://') || model.startsWith('ds://')) {
+        return model;
+    }
+
+    if (!folder) {
+        throw new Error(
+            `Yandex AI Studio: --folder is required when --model is a short name (got "${model}")`,
+        );
+    }
+
+    const parts = model.split('/');
+    if (parts.length === 1) {
+        return `gpt://${folder}/${model}/latest`;
+    }
+
+    return `gpt://${folder}/${model}`;
+}
+
+export class YandexGptClient implements LLMClient {
+    readonly name = 'yandexgpt';
+
+    private readonly token: string;
+    private readonly folder: string;
+    private readonly model: string;
+    private readonly endpoint: string;
+    private readonly timeout: number;
+
+    constructor(options: YandexGptClientOptions) {
+        this.token = options.token;
+        this.folder = options.folder;
+        this.model = options.model;
+        this.endpoint = options.endpoint || DEFAULT_ENDPOINT;
+        this.timeout = options.timeout ?? 60_000;
+    }
+
+    async complete(
+        messages: ChatMessage[],
+        options: CompletionOptions,
+    ): Promise<CompletionResult> {
+        const yandexMessages: YandexMessage[] = messages.map((m) => ({
+            role: m.role,
+            text: m.content,
+        }));
+
+        try {
+            const {data} = await axios.post<YandexCompletionResponse>(
+                this.endpoint,
+                {
+                    modelUri: resolveModelUri(this.model, this.folder),
+                    completionOptions: {
+                        stream: false,
+                        temperature: options.temperature,
+                        maxTokens: String(options.maxTokens),
+                    },
+                    messages: yandexMessages,
+                },
+                {
+                    timeout: this.timeout,
+                    headers: {
+                        Authorization: yandexAuthHeader(this.token),
+                        'Content-Type': 'application/json',
+                        'User-Agent': 'github.com/diplodoc-platform/cli',
+                    },
+                },
+            );
+
+            const alternative = data.result.alternatives?.[0];
+            if (!alternative) {
+                throw new LLMResponseError('Yandex AI Studio returned no alternatives');
+            }
+
+            if (alternative.status === 'ALTERNATIVE_STATUS_CONTENT_FILTER') {
+                throw new LLMResponseError(
+                    'Yandex AI Studio rejected the request (content filter)',
+                    false,
+                );
+            }
+
+            return {
+                text: alternative.message.text,
+                usage: {
+                    inputTokens: Number(data.result.usage?.inputTextTokens ?? 0),
+                    outputTokens: Number(data.result.usage?.completionTokens ?? 0),
+                },
+            };
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+            if (error instanceof AxiosError && error.response) {
+                const {status, statusText, data} = error.response;
+                const message = data?.message || data?.error?.message || statusText;
+
+                if (status === 401 || status === 403) {
+                    throw new LLMAuthError(`Yandex AI Studio auth failed: ${message}`);
+                }
+                if (status === 429) {
+                    throw new LLMRateLimitError(message);
+                }
+                throw new LLMRequestError(status, message, {
+                    retryable: status >= 500 && status < 600,
+                });
+            }
+            throw error;
+        }
+    }
+}

--- a/src/commands/translate/providers/ai/clients/yandexgpt.ts
+++ b/src/commands/translate/providers/ai/clients/yandexgpt.ts
@@ -1,8 +1,8 @@
 import type {ChatMessage, CompletionOptions, CompletionResult, LLMClient} from './types';
 
-import axios, {AxiosError} from 'axios';
+import axios from 'axios';
 
-import {LLMAuthError, LLMRateLimitError, LLMRequestError, LLMResponseError} from '../utils';
+import {LLMResponseError, throwLLMError} from '../utils';
 import {yandexAuthHeader} from '../auth';
 
 const DEFAULT_ENDPOINT = 'https://llm.api.cloud.yandex.net/foundationModels/v1/completion';
@@ -29,8 +29,8 @@ type YandexCompletionResponse = {
 
 export type YandexGptClientOptions = {
     token: string;
-    folder: string;
     model: string;
+    folder?: string;
     endpoint?: string;
     timeout?: number;
 };
@@ -70,16 +70,13 @@ export class YandexGptClient implements LLMClient {
 
     constructor(options: YandexGptClientOptions) {
         this.token = options.token;
-        this.folder = options.folder;
+        this.folder = options.folder || '';
         this.model = options.model;
         this.endpoint = options.endpoint || DEFAULT_ENDPOINT;
         this.timeout = options.timeout ?? 60_000;
     }
 
-    async complete(
-        messages: ChatMessage[],
-        options: CompletionOptions,
-    ): Promise<CompletionResult> {
+    async complete(messages: ChatMessage[], options: CompletionOptions): Promise<CompletionResult> {
         const yandexMessages: YandexMessage[] = messages.map((m) => ({
             role: m.role,
             text: m.content,
@@ -126,23 +123,8 @@ export class YandexGptClient implements LLMClient {
                     outputTokens: Number(data.result.usage?.completionTokens ?? 0),
                 },
             };
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (error: any) {
-            if (error instanceof AxiosError && error.response) {
-                const {status, statusText, data} = error.response;
-                const message = data?.message || data?.error?.message || statusText;
-
-                if (status === 401 || status === 403) {
-                    throw new LLMAuthError(`Yandex AI Studio auth failed: ${message}`);
-                }
-                if (status === 429) {
-                    throw new LLMRateLimitError(message);
-                }
-                throw new LLMRequestError(status, message, {
-                    retryable: status >= 500 && status < 600,
-                });
-            }
-            throw error;
+        } catch (error) {
+            throwLLMError(error, 'Yandex AI Studio');
         }
     }
 }

--- a/src/commands/translate/providers/ai/clients/yandexgpt.ts
+++ b/src/commands/translate/providers/ai/clients/yandexgpt.ts
@@ -5,7 +5,8 @@ import axios from 'axios';
 import {LLMResponseError, throwLLMError} from '../utils';
 import {yandexAuthHeader} from '../auth';
 
-const DEFAULT_ENDPOINT = 'https://llm.api.cloud.yandex.net/foundationModels/v1/completion';
+const DEFAULT_BASE_URL = 'https://llm.api.cloud.yandex.net';
+const COMPLETION_PATH = '/foundationModels/v1/completion';
 
 type YandexMessage = {
     role: 'system' | 'user' | 'assistant';
@@ -31,8 +32,9 @@ export type YandexGptClientOptions = {
     token: string;
     model: string;
     folder?: string;
-    endpoint?: string;
+    baseUrl?: string;
     timeout?: number;
+    headers?: Record<string, string>;
 };
 
 /**
@@ -67,13 +69,15 @@ export class YandexGptClient implements LLMClient {
     private readonly model: string;
     private readonly endpoint: string;
     private readonly timeout: number;
+    private readonly headers: Record<string, string>;
 
     constructor(options: YandexGptClientOptions) {
         this.token = options.token;
         this.folder = options.folder || '';
         this.model = options.model;
-        this.endpoint = options.endpoint || DEFAULT_ENDPOINT;
+        this.endpoint = (options.baseUrl || DEFAULT_BASE_URL).replace(/\/$/, '') + COMPLETION_PATH;
         this.timeout = options.timeout ?? 60_000;
+        this.headers = options.headers || {};
     }
 
     async complete(messages: ChatMessage[], options: CompletionOptions): Promise<CompletionResult> {
@@ -100,6 +104,7 @@ export class YandexGptClient implements LLMClient {
                         Authorization: yandexAuthHeader(this.token),
                         'Content-Type': 'application/json',
                         'User-Agent': 'github.com/diplodoc-platform/cli',
+                        ...this.headers,
                     },
                 },
             );
@@ -112,6 +117,14 @@ export class YandexGptClient implements LLMClient {
             if (alternative.status === 'ALTERNATIVE_STATUS_CONTENT_FILTER') {
                 throw new LLMResponseError(
                     'Yandex AI Studio rejected the request (content filter)',
+                    false,
+                );
+            }
+
+            if (alternative.status === 'ALTERNATIVE_STATUS_TRUNCATED_FINAL') {
+                throw new LLMResponseError(
+                    'Yandex AI Studio response was truncated. ' +
+                        'Increase --max-output-tokens or reduce --max-batch-tokens.',
                     false,
                 );
             }

--- a/src/commands/translate/providers/ai/config.ts
+++ b/src/commands/translate/providers/ai/config.ts
@@ -1,0 +1,145 @@
+import {cyan, gray} from 'chalk';
+import {dedent} from 'ts-dedent';
+
+import {option} from '~/core/config';
+
+const auth = option({
+    flags: '--auth <value>',
+    desc: `
+        Authorization token for the AI provider.
+        Accepts the raw token value or a path to a file containing the token.
+
+        Yandex AI Studio: IAM token (Bearer) or service-account API key.
+        OpenAI / OpenRouter: Bearer key (sk-...).
+        Anthropic: x-api-key (sk-ant-...).
+    `,
+});
+
+const folder = option({
+    flags: '--folder <value>',
+    desc: `
+        Yandex AI Studio folder ID. Required when --model is a short model name
+        (e.g. "yandexgpt-lite") so the full gpt:// URI can be built.
+    `,
+});
+
+const model = option({
+    flags: '--model <value>',
+    desc: `
+        Target model identifier.
+
+        Yandex AI Studio: short name ("yandexgpt-lite", "yandexgpt") or full URI ("gpt://<folder>/yandexgpt/latest").
+        OpenAI: e.g. "gpt-4o-mini".
+        OpenRouter: e.g. "anthropic/claude-3.5-sonnet".
+        Anthropic: e.g. "claude-sonnet-4-5".
+    `,
+});
+
+const apiBase = option({
+    flags: '--api-base <url>',
+    desc: `
+        Override the API base URL (useful for self-hosted or compatible endpoints).
+    `,
+});
+
+const systemPrompt = option({
+    flags: '--system-prompt <value>',
+    desc: `
+        System prompt for the LLM. Accepts a string or a path to a file.
+
+        Supports placeholders: {{source}}, {{target}}, {{glossary}}, {{separator}}, {{fragments}}.
+
+        By default the user prompt is appended to the built-in technical-translator system prompt.
+        Use --prompt-mode replace to fully replace the default.
+    `,
+});
+
+const userPrompt = option({
+    flags: '--user-prompt <value>',
+    desc: `
+        User prompt template. Accepts a string or a path to a file.
+        Supports placeholders: {{source}}, {{target}}, {{glossary}}, {{separator}}, {{fragments}}, {{text}}.
+    `,
+});
+
+const promptMode = option({
+    flags: '--prompt-mode <mode>',
+    desc: `
+        How the user-supplied system prompt interacts with the default one.
+
+        ${cyan('append')} (default) — supplied system prompt is appended to the built-in default.
+        ${cyan('replace')} — supplied system prompt fully replaces the built-in default.
+    `,
+    choices: ['append', 'replace'],
+    default: 'append',
+});
+
+const glossaryExample = gray(dedent`
+    glossaryPairs:
+      - sourceText: string
+        translatedText: string
+`);
+
+const glossary = option({
+    flags: '--glossary <path>',
+    desc: `
+        Path to a YAML file with required term translations.
+
+        Config example:
+        ${glossaryExample}
+    `,
+});
+
+const temperature = option({
+    flags: '--temperature <num>',
+    desc: 'Sampling temperature. Defaults to 0 for deterministic translation.',
+    parser: (value: string) => Number(value),
+    default: 0,
+});
+
+const maxOutputTokens = option({
+    flags: '--max-output-tokens <num>',
+    desc: 'Maximum tokens in a single LLM response. Default 4000.',
+    parser: (value: string) => parseInt(value, 10),
+    default: 4000,
+});
+
+const maxBatchTokens = option({
+    flags: '--max-batch-tokens <num>',
+    desc: `
+        Token budget for a single LLM request. Translation units are batched up to this
+        limit and sent together. Smaller values are safer but slower. Default 2000.
+    `,
+    parser: (value: string) => parseInt(value, 10),
+    default: 2000,
+});
+
+const maxConcurrency = option({
+    flags: '--max-concurrency <num>',
+    desc: 'Maximum concurrent LLM requests. Default 5.',
+    parser: (value: string) => parseInt(value, 10),
+    default: 5,
+});
+
+const retry = option({
+    flags: '--retry <num>',
+    desc: 'Number of retries on retryable LLM errors. Default 3.',
+    parser: (value: string) => parseInt(value, 10),
+    default: 3,
+});
+
+export const options = {
+    auth,
+    folder,
+    model,
+    apiBase,
+    systemPrompt,
+    userPrompt,
+    promptMode,
+    glossary,
+    temperature,
+    maxOutputTokens,
+    maxBatchTokens,
+    maxConcurrency,
+    retry,
+};

--- a/src/commands/translate/providers/ai/config.ts
+++ b/src/commands/translate/providers/ai/config.ts
@@ -1,7 +1,7 @@
 import {cyan, gray} from 'chalk';
 import {dedent} from 'ts-dedent';
 
-import {option} from '~/core/config';
+import {option, toArray} from '~/core/config';
 
 const auth = option({
     flags: '--auth <value>',
@@ -12,6 +12,8 @@ const auth = option({
         Yandex AI Studio: IAM token (Bearer) or service-account API key.
         OpenAI / OpenRouter: Bearer key (sk-...).
         Anthropic: x-api-key (sk-ant-...).
+
+        Env fallback: YANDEX_API_KEY / YC_IAM_TOKEN, OPENAI_API_KEY, OPENROUTER_API_KEY, ANTHROPIC_API_KEY.
     `,
 });
 
@@ -38,8 +40,28 @@ const model = option({
 const apiBase = option({
     flags: '--api-base <url>',
     desc: `
-        Override the API base URL (useful for self-hosted or compatible endpoints).
+        Override the API base URL. Useful for self-hosted and internal
+        installations of compatible APIs.
+
+        The provider request path is appended automatically:
+        yandexgpt: <base>/foundationModels/v1/completion
+        openai / openrouter: <base>/chat/completions (include /v1 into the base)
+        anthropic: <base>/messages (include /v1 into the base)
+
+        Env fallback: OPENAI_BASE_URL, OPENROUTER_BASE_URL, ANTHROPIC_BASE_URL.
     `,
+});
+
+const apiHeader = option({
+    flags: '--api-header <header>',
+    desc: `
+        Additional HTTP header for LLM API requests in "Name: value" format.
+        Repeat the option to pass several headers.
+        Useful for internal gateways which require extra auth headers.
+
+        Config alternative: ${cyan('apiHeaders')} object in the yfm config.
+    `,
+    parser: toArray,
 });
 
 const systemPrompt = option({
@@ -67,11 +89,11 @@ const promptMode = option({
     desc: `
         How the user-supplied system prompt interacts with the default one.
 
-        ${cyan('append')} (default) — supplied system prompt is appended to the built-in default.
-        ${cyan('replace')} — supplied system prompt fully replaces the built-in default.
+        ${cyan('append')} - supplied system prompt is appended to the built-in default.
+        ${cyan('replace')} - supplied system prompt fully replaces the built-in default.
     `,
     choices: ['append', 'replace'],
-    default: 'append',
+    defaultInfo: 'append',
 });
 
 const glossaryExample = gray(dedent`
@@ -94,38 +116,38 @@ const temperature = option({
     flags: '--temperature <num>',
     desc: 'Sampling temperature. Defaults to 0 for deterministic translation.',
     parser: (value: string) => Number(value),
-    default: 0,
+    defaultInfo: 0,
 });
 
 const maxOutputTokens = option({
     flags: '--max-output-tokens <num>',
-    desc: 'Maximum tokens in a single LLM response. Default 4000.',
+    desc: 'Maximum tokens in a single LLM response.',
     parser: (value: string) => parseInt(value, 10),
-    default: 4000,
+    defaultInfo: 4000,
 });
 
 const maxBatchTokens = option({
     flags: '--max-batch-tokens <num>',
     desc: `
         Token budget for a single LLM request. Translation units are batched up to this
-        limit and sent together. Smaller values are safer but slower. Default 2000.
+        limit and sent together. Smaller values are safer but slower.
     `,
     parser: (value: string) => parseInt(value, 10),
-    default: 2000,
+    defaultInfo: 2000,
 });
 
 const maxConcurrency = option({
     flags: '--max-concurrency <num>',
-    desc: 'Maximum concurrent LLM requests. Default 5.',
+    desc: 'Maximum concurrent LLM requests.',
     parser: (value: string) => parseInt(value, 10),
-    default: 5,
+    defaultInfo: 5,
 });
 
 const retry = option({
     flags: '--retry <num>',
-    desc: 'Number of retries on retryable LLM errors. Default 3.',
+    desc: 'Number of retries on retryable LLM errors.',
     parser: (value: string) => parseInt(value, 10),
-    default: 3,
+    defaultInfo: 3,
 });
 
 export const options = {
@@ -133,6 +155,7 @@ export const options = {
     folder,
     model,
     apiBase,
+    apiHeader,
     systemPrompt,
     userPrompt,
     promptMode,

--- a/src/commands/translate/providers/ai/config.ts
+++ b/src/commands/translate/providers/ai/config.ts
@@ -115,14 +115,14 @@ const glossary = option({
 const temperature = option({
     flags: '--temperature <num>',
     desc: 'Sampling temperature. Defaults to 0 for deterministic translation.',
-    parser: (value: string) => Number(value),
+    parser: Number,
     defaultInfo: 0,
 });
 
 const maxOutputTokens = option({
     flags: '--max-output-tokens <num>',
     desc: 'Maximum tokens in a single LLM response.',
-    parser: (value: string) => parseInt(value, 10),
+    parser: (value: string) => Number.parseInt(value, 10),
     defaultInfo: 4000,
 });
 
@@ -132,21 +132,21 @@ const maxBatchTokens = option({
         Token budget for a single LLM request. Translation units are batched up to this
         limit and sent together. Smaller values are safer but slower.
     `,
-    parser: (value: string) => parseInt(value, 10),
+    parser: (value: string) => Number.parseInt(value, 10),
     defaultInfo: 2000,
 });
 
 const maxConcurrency = option({
     flags: '--max-concurrency <num>',
     desc: 'Maximum concurrent LLM requests.',
-    parser: (value: string) => parseInt(value, 10),
+    parser: (value: string) => Number.parseInt(value, 10),
     defaultInfo: 5,
 });
 
 const retry = option({
     flags: '--retry <num>',
     desc: 'Number of retries on retryable LLM errors.',
-    parser: (value: string) => parseInt(value, 10),
+    parser: (value: string) => Number.parseInt(value, 10),
     defaultInfo: 3,
 });
 

--- a/src/commands/translate/providers/ai/index.ts
+++ b/src/commands/translate/providers/ai/index.ts
@@ -1,0 +1,271 @@
+import type {BaseProgram} from '~/core/program';
+import type {Translate, TranslateArgs, TranslateConfig} from '~/commands/translate';
+import type {LLMClient} from './clients/types';
+
+import {ok} from 'assert';
+import {join} from 'node:path';
+
+import {getHooks as getBaseHooks} from '~/core/program';
+import {getHooks} from '~/commands/translate';
+import {defined, resolveConfig} from '~/core/config';
+import {own} from '~/core/utils';
+
+import {Provider} from './provider';
+import {options} from './config';
+import {resolveToken} from './auth';
+import {resolvePromptValue} from './prompts';
+import {YandexGptClient} from './clients/yandexgpt';
+import {AnthropicClient} from './clients/anthropic';
+import {createOpenAIClient, createOpenRouterClient} from './clients/openai';
+
+import type {GlossaryPair, PromptMode} from './prompts';
+
+const PROVIDER_NAMES = ['yandexgpt', 'openai', 'openrouter', 'anthropic'] as const;
+type ProviderName = (typeof PROVIDER_NAMES)[number];
+
+const ExtensionName = 'AITranslation';
+
+const DEFAULT_MODELS: Record<ProviderName, string> = {
+    yandexgpt: 'yandexgpt-lite',
+    openai: 'gpt-4o-mini',
+    openrouter: 'openai/gpt-4o-mini',
+    anthropic: 'claude-sonnet-4-5',
+};
+
+const ENV_VARS: Record<ProviderName, string[]> = {
+    yandexgpt: ['YANDEX_API_KEY', 'YC_IAM_TOKEN'],
+    openai: ['OPENAI_API_KEY'],
+    openrouter: ['OPENROUTER_API_KEY'],
+    anthropic: ['ANTHROPIC_API_KEY'],
+};
+
+type Args = {
+    auth?: string;
+    folder?: string;
+    model?: string;
+    apiBase?: string;
+    systemPrompt?: string;
+    userPrompt?: string;
+    promptMode?: PromptMode;
+    glossary?: string;
+    temperature?: number;
+    maxOutputTokens?: number;
+    maxBatchTokens?: number;
+    maxConcurrency?: number;
+    retry?: number;
+};
+
+type Config = {
+    auth: string;
+    folder?: string;
+    model: string;
+    apiBase?: string;
+    systemPrompt?: string;
+    userPrompt?: string;
+    promptMode: PromptMode;
+    glossary?: string;
+    glossaryPairs: GlossaryPair[];
+    temperature: number;
+    maxOutputTokens: number;
+    maxBatchTokens: number;
+    maxConcurrency: number;
+    retry: number;
+};
+
+export type AITranslationConfig = TranslateConfig & Config;
+
+function readEnvAuth(provider: ProviderName): string | undefined {
+    for (const name of ENV_VARS[provider]) {
+        const value = process.env[name];
+        if (value) {
+            return value;
+        }
+    }
+    return undefined;
+}
+
+function makeClientFactory(provider: ProviderName) {
+    return function clientFactory(config: AITranslationConfig): LLMClient {
+        switch (provider) {
+            case 'yandexgpt':
+                ok(config.folder, 'Yandex AI Studio: --folder is required');
+                return new YandexGptClient({
+                    token: config.auth,
+                    folder: config.folder,
+                    model: config.model,
+                    endpoint: config.apiBase,
+                });
+            case 'openai':
+                return createOpenAIClient({
+                    token: config.auth,
+                    model: config.model,
+                    baseUrl: config.apiBase,
+                });
+            case 'openrouter':
+                return createOpenRouterClient({
+                    token: config.auth,
+                    model: config.model,
+                    baseUrl: config.apiBase,
+                });
+            case 'anthropic':
+                return new AnthropicClient({
+                    token: config.auth,
+                    model: config.model,
+                    baseUrl: config.apiBase,
+                });
+        }
+    };
+}
+
+function numberOr(value: unknown, fallback: number): number {
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+    const n = Number(value);
+    return Number.isFinite(n) ? n : fallback;
+}
+
+function intOr(value: unknown, fallback: number): number {
+    if (value === null || value === undefined || value === '') {
+        return fallback;
+    }
+    const n = parseInt(String(value), 10);
+    return Number.isFinite(n) ? n : fallback;
+}
+
+export class Extension {
+    apply(program: Translate) {
+        getBaseHooks(program).Command.tap(ExtensionName, (_command, opts) => {
+            const providerOption = opts.find((option) => option.flags.match('--provider'));
+            ok(providerOption, 'Unable to configure `--provider` option.');
+
+            const choices = providerOption.argChoices || [];
+            for (const name of PROVIDER_NAMES) {
+                if (!choices.includes(name)) {
+                    choices.push(name);
+                }
+            }
+            providerOption.choices(choices);
+        });
+
+        for (const providerName of PROVIDER_NAMES) {
+            this.registerProvider(program, providerName);
+        }
+    }
+
+    private registerProvider(program: Translate, providerName: ProviderName) {
+        getHooks(program)
+            .Provider.for(providerName)
+            .tap(`${ExtensionName}.${providerName}`, (_provider, _config) => {
+                getBaseHooks(program).Command.tap(
+                    `${ExtensionName}.${providerName}`,
+                    (command) => {
+                        command
+                            .addOption(options.auth)
+                            .addOption(options.model)
+                            .addOption(options.apiBase)
+                            .addOption(options.systemPrompt)
+                            .addOption(options.userPrompt)
+                            .addOption(options.promptMode)
+                            .addOption(options.glossary)
+                            .addOption(options.temperature)
+                            .addOption(options.maxOutputTokens)
+                            .addOption(options.maxBatchTokens)
+                            .addOption(options.maxConcurrency)
+                            .addOption(options.retry);
+
+                        if (providerName === 'yandexgpt') {
+                            command.addOption(options.folder);
+                        }
+                    },
+                );
+
+                getBaseHooks(
+                    program as BaseProgram<
+                        TranslateConfig & Partial<Config>,
+                        TranslateArgs & Partial<Args>
+                    >,
+                ).Config.tapPromise(
+                    `${ExtensionName}.${providerName}`,
+                    async (config, args) => {
+                        ok(!config.auth, 'Do not store `authToken` in public config');
+
+                        const rawAuth = args.auth || readEnvAuth(providerName);
+                        ok(
+                            rawAuth,
+                            `Required param --auth is not configured for provider "${providerName}"`,
+                        );
+                        config.auth = resolveToken(rawAuth);
+
+                        const model =
+                            (defined('model', args, config) as string | undefined) ||
+                            DEFAULT_MODELS[providerName];
+                        config.model = model;
+
+                        const apiBase = defined('apiBase', args, config);
+                        if (apiBase) {
+                            config.apiBase = apiBase;
+                        }
+
+                        if (providerName === 'yandexgpt') {
+                            config.folder = defined('folder', args, config);
+                            if (!config.folder && !model.startsWith('gpt://')) {
+                                ok(
+                                    false,
+                                    'Yandex AI Studio: --folder is required when --model is a short name',
+                                );
+                            }
+                        }
+
+                        config.systemPrompt = resolvePromptValue(
+                            defined('systemPrompt', args, config) || undefined,
+                        );
+                        config.userPrompt = resolvePromptValue(
+                            defined('userPrompt', args, config) || undefined,
+                        );
+                        config.promptMode =
+                            (defined('promptMode', args, config) as PromptMode) || 'append';
+
+                        config.temperature = numberOr(defined('temperature', args, config), 0);
+                        config.maxOutputTokens = intOr(
+                            defined('maxOutputTokens', args, config),
+                            4000,
+                        );
+                        config.maxBatchTokens = intOr(
+                            defined('maxBatchTokens', args, config),
+                            2000,
+                        );
+                        config.maxConcurrency = intOr(
+                            defined('maxConcurrency', args, config),
+                            5,
+                        );
+                        config.retry = intOr(defined('retry', args, config), 3);
+
+                        let glossary: AbsolutePath | undefined;
+                        if (own<string, 'glossary'>(args, 'glossary')) {
+                            glossary = join(args.input, args.glossary);
+                        } else if (own<string, 'glossary'>(config, 'glossary')) {
+                            glossary = config.resolve(config.glossary);
+                        }
+
+                        if (glossary) {
+                            const glossaryConfig = await resolveConfig(glossary, {
+                                defaults: {glossaryPairs: []},
+                            });
+                            config.glossaryPairs = glossaryConfig.glossaryPairs || [];
+                        } else {
+                            config.glossaryPairs = [];
+                        }
+
+                        return config;
+                    },
+                );
+
+                const provider = new Provider(makeClientFactory(providerName), _config);
+
+                provider.pipe(program.logger);
+
+                return provider;
+            });
+    }
+}

--- a/src/commands/translate/providers/ai/index.ts
+++ b/src/commands/translate/providers/ai/index.ts
@@ -1,6 +1,7 @@
 import type {BaseProgram} from '~/core/program';
 import type {Translate, TranslateArgs, TranslateConfig} from '~/commands/translate';
 import type {LLMClient} from './clients/types';
+import type {GlossaryPair, PromptMode} from './prompts';
 
 import {ok} from 'assert';
 import {join} from 'node:path';
@@ -17,8 +18,6 @@ import {resolvePromptValue} from './prompts';
 import {YandexGptClient} from './clients/yandexgpt';
 import {AnthropicClient} from './clients/anthropic';
 import {createOpenAIClient, createOpenRouterClient} from './clients/openai';
-
-import type {GlossaryPair, PromptMode} from './prompts';
 
 const PROVIDER_NAMES = ['yandexgpt', 'openai', 'openrouter', 'anthropic'] as const;
 type ProviderName = (typeof PROVIDER_NAMES)[number];
@@ -88,7 +87,6 @@ function makeClientFactory(provider: ProviderName) {
     return function clientFactory(config: AITranslationConfig): LLMClient {
         switch (provider) {
             case 'yandexgpt':
-                ok(config.folder, 'Yandex AI Studio: --folder is required');
                 return new YandexGptClient({
                     token: config.auth,
                     folder: config.folder,
@@ -156,112 +154,97 @@ export class Extension {
     private registerProvider(program: Translate, providerName: ProviderName) {
         getHooks(program)
             .Provider.for(providerName)
-            .tap(`${ExtensionName}.${providerName}`, (_provider, _config) => {
-                getBaseHooks(program).Command.tap(
-                    `${ExtensionName}.${providerName}`,
-                    (command) => {
-                        command
-                            .addOption(options.auth)
-                            .addOption(options.model)
-                            .addOption(options.apiBase)
-                            .addOption(options.systemPrompt)
-                            .addOption(options.userPrompt)
-                            .addOption(options.promptMode)
-                            .addOption(options.glossary)
-                            .addOption(options.temperature)
-                            .addOption(options.maxOutputTokens)
-                            .addOption(options.maxBatchTokens)
-                            .addOption(options.maxConcurrency)
-                            .addOption(options.retry);
+            .tap(`${ExtensionName}.${providerName}`, (_provider, config) => {
+                getBaseHooks(program).Command.tap(`${ExtensionName}.${providerName}`, (command) => {
+                    command
+                        .addOption(options.auth)
+                        .addOption(options.model)
+                        .addOption(options.apiBase)
+                        .addOption(options.systemPrompt)
+                        .addOption(options.userPrompt)
+                        .addOption(options.promptMode)
+                        .addOption(options.glossary)
+                        .addOption(options.temperature)
+                        .addOption(options.maxOutputTokens)
+                        .addOption(options.maxBatchTokens)
+                        .addOption(options.maxConcurrency)
+                        .addOption(options.retry);
 
-                        if (providerName === 'yandexgpt') {
-                            command.addOption(options.folder);
-                        }
-                    },
-                );
+                    if (providerName === 'yandexgpt') {
+                        command.addOption(options.folder);
+                    }
+                });
 
                 getBaseHooks(
                     program as BaseProgram<
                         TranslateConfig & Partial<Config>,
                         TranslateArgs & Partial<Args>
                     >,
-                ).Config.tapPromise(
-                    `${ExtensionName}.${providerName}`,
-                    async (config, args) => {
-                        ok(!config.auth, 'Do not store `authToken` in public config');
+                ).Config.tapPromise(`${ExtensionName}.${providerName}`, async (config, args) => {
+                    ok(!config.auth, 'Do not store `authToken` in public config');
 
-                        const rawAuth = args.auth || readEnvAuth(providerName);
+                    const rawAuth = args.auth || readEnvAuth(providerName);
+                    ok(
+                        rawAuth,
+                        `Required param --auth is not configured for provider "${providerName}"`,
+                    );
+                    config.auth = resolveToken(rawAuth);
+
+                    const model =
+                        (defined('model', args, config) as string | undefined) ||
+                        DEFAULT_MODELS[providerName];
+                    config.model = model;
+
+                    const apiBase = defined('apiBase', args, config);
+                    if (apiBase) {
+                        config.apiBase = apiBase;
+                    }
+
+                    if (providerName === 'yandexgpt') {
+                        config.folder = defined('folder', args, config);
+
+                        const qualified = model.startsWith('gpt://') || model.startsWith('ds://');
                         ok(
-                            rawAuth,
-                            `Required param --auth is not configured for provider "${providerName}"`,
+                            config.folder || qualified,
+                            'Yandex AI Studio: --folder is required when --model is a short name',
                         );
-                        config.auth = resolveToken(rawAuth);
+                    }
 
-                        const model =
-                            (defined('model', args, config) as string | undefined) ||
-                            DEFAULT_MODELS[providerName];
-                        config.model = model;
+                    config.systemPrompt = resolvePromptValue(
+                        defined('systemPrompt', args, config) || undefined,
+                    );
+                    config.userPrompt = resolvePromptValue(
+                        defined('userPrompt', args, config) || undefined,
+                    );
+                    config.promptMode =
+                        (defined('promptMode', args, config) as PromptMode) || 'append';
 
-                        const apiBase = defined('apiBase', args, config);
-                        if (apiBase) {
-                            config.apiBase = apiBase;
-                        }
+                    config.temperature = numberOr(defined('temperature', args, config), 0);
+                    config.maxOutputTokens = intOr(defined('maxOutputTokens', args, config), 4000);
+                    config.maxBatchTokens = intOr(defined('maxBatchTokens', args, config), 2000);
+                    config.maxConcurrency = intOr(defined('maxConcurrency', args, config), 5);
+                    config.retry = intOr(defined('retry', args, config), 3);
 
-                        if (providerName === 'yandexgpt') {
-                            config.folder = defined('folder', args, config);
-                            if (!config.folder && !model.startsWith('gpt://')) {
-                                ok(
-                                    false,
-                                    'Yandex AI Studio: --folder is required when --model is a short name',
-                                );
-                            }
-                        }
+                    let glossary: AbsolutePath | undefined;
+                    if (own<string, 'glossary'>(args, 'glossary')) {
+                        glossary = join(args.input, args.glossary);
+                    } else if (own<string, 'glossary'>(config, 'glossary')) {
+                        glossary = config.resolve(config.glossary);
+                    }
 
-                        config.systemPrompt = resolvePromptValue(
-                            defined('systemPrompt', args, config) || undefined,
-                        );
-                        config.userPrompt = resolvePromptValue(
-                            defined('userPrompt', args, config) || undefined,
-                        );
-                        config.promptMode =
-                            (defined('promptMode', args, config) as PromptMode) || 'append';
+                    if (glossary) {
+                        const glossaryConfig = await resolveConfig(glossary, {
+                            defaults: {glossaryPairs: []},
+                        });
+                        config.glossaryPairs = glossaryConfig.glossaryPairs || [];
+                    } else {
+                        config.glossaryPairs = [];
+                    }
 
-                        config.temperature = numberOr(defined('temperature', args, config), 0);
-                        config.maxOutputTokens = intOr(
-                            defined('maxOutputTokens', args, config),
-                            4000,
-                        );
-                        config.maxBatchTokens = intOr(
-                            defined('maxBatchTokens', args, config),
-                            2000,
-                        );
-                        config.maxConcurrency = intOr(
-                            defined('maxConcurrency', args, config),
-                            5,
-                        );
-                        config.retry = intOr(defined('retry', args, config), 3);
+                    return config;
+                });
 
-                        let glossary: AbsolutePath | undefined;
-                        if (own<string, 'glossary'>(args, 'glossary')) {
-                            glossary = join(args.input, args.glossary);
-                        } else if (own<string, 'glossary'>(config, 'glossary')) {
-                            glossary = config.resolve(config.glossary);
-                        }
-
-                        if (glossary) {
-                            const glossaryConfig = await resolveConfig(glossary, {
-                                defaults: {glossaryPairs: []},
-                            });
-                            config.glossaryPairs = glossaryConfig.glossaryPairs || [];
-                        } else {
-                            config.glossaryPairs = [];
-                        }
-
-                        return config;
-                    },
-                );
-
-                const provider = new Provider(makeClientFactory(providerName), _config);
+                const provider = new Provider(makeClientFactory(providerName), config);
 
                 provider.pipe(program.logger);
 

--- a/src/commands/translate/providers/ai/index.ts
+++ b/src/commands/translate/providers/ai/index.ts
@@ -24,6 +24,8 @@ type ProviderName = (typeof PROVIDER_NAMES)[number];
 
 const ExtensionName = 'AITranslation';
 
+const DEFAULT_TIMEOUT = 60_000;
+
 const DEFAULT_MODELS: Record<ProviderName, string> = {
     yandexgpt: 'yandexgpt-lite',
     openai: 'gpt-4o-mini',
@@ -31,11 +33,18 @@ const DEFAULT_MODELS: Record<ProviderName, string> = {
     anthropic: 'claude-sonnet-4-5',
 };
 
-const ENV_VARS: Record<ProviderName, string[]> = {
+const ENV_AUTH: Record<ProviderName, string[]> = {
     yandexgpt: ['YANDEX_API_KEY', 'YC_IAM_TOKEN'],
     openai: ['OPENAI_API_KEY'],
     openrouter: ['OPENROUTER_API_KEY'],
     anthropic: ['ANTHROPIC_API_KEY'],
+};
+
+const ENV_BASE_URL: Record<ProviderName, string[]> = {
+    yandexgpt: [],
+    openai: ['OPENAI_BASE_URL'],
+    openrouter: ['OPENROUTER_BASE_URL'],
+    anthropic: ['ANTHROPIC_BASE_URL'],
 };
 
 type Args = {
@@ -43,6 +52,7 @@ type Args = {
     folder?: string;
     model?: string;
     apiBase?: string;
+    apiHeader?: string[];
     systemPrompt?: string;
     userPrompt?: string;
     promptMode?: PromptMode;
@@ -59,6 +69,7 @@ type Config = {
     folder?: string;
     model: string;
     apiBase?: string;
+    apiHeaders: Record<string, string>;
     systemPrompt?: string;
     userPrompt?: string;
     promptMode: PromptMode;
@@ -73,8 +84,8 @@ type Config = {
 
 export type AITranslationConfig = TranslateConfig & Config;
 
-function readEnvAuth(provider: ProviderName): string | undefined {
-    for (const name of ENV_VARS[provider]) {
+function readEnv(names: string[]): string | undefined {
+    for (const name of names) {
         const value = process.env[name];
         if (value) {
             return value;
@@ -83,34 +94,50 @@ function readEnvAuth(provider: ProviderName): string | undefined {
     return undefined;
 }
 
+/**
+ * Accepts headers as a list of "Name: value" strings (CLI) or as a plain object (config).
+ */
+function parseHeaders(value: unknown): Record<string, string> {
+    if (!value) {
+        return {};
+    }
+
+    if (Array.isArray(value)) {
+        const headers: Record<string, string> = {};
+        for (const entry of value) {
+            const match = String(entry).match(/^([^:]+):\s*(.*)$/);
+            ok(match, `Invalid api header "${entry}". Expected "Name: value" format.`);
+            headers[match[1].trim()] = match[2];
+        }
+        return headers;
+    }
+
+    if (typeof value === 'object') {
+        return {...(value as Record<string, string>)};
+    }
+
+    return parseHeaders([value]);
+}
+
 function makeClientFactory(provider: ProviderName) {
     return function clientFactory(config: AITranslationConfig): LLMClient {
+        const common = {
+            token: config.auth,
+            model: config.model,
+            baseUrl: config.apiBase,
+            timeout: config.timeout,
+            headers: config.apiHeaders,
+        };
+
         switch (provider) {
             case 'yandexgpt':
-                return new YandexGptClient({
-                    token: config.auth,
-                    folder: config.folder,
-                    model: config.model,
-                    endpoint: config.apiBase,
-                });
+                return new YandexGptClient({...common, folder: config.folder});
             case 'openai':
-                return createOpenAIClient({
-                    token: config.auth,
-                    model: config.model,
-                    baseUrl: config.apiBase,
-                });
+                return createOpenAIClient(common);
             case 'openrouter':
-                return createOpenRouterClient({
-                    token: config.auth,
-                    model: config.model,
-                    baseUrl: config.apiBase,
-                });
+                return createOpenRouterClient(common);
             case 'anthropic':
-                return new AnthropicClient({
-                    token: config.auth,
-                    model: config.model,
-                    baseUrl: config.apiBase,
-                });
+                return new AnthropicClient(common);
         }
     };
 }
@@ -160,6 +187,7 @@ export class Extension {
                         .addOption(options.auth)
                         .addOption(options.model)
                         .addOption(options.apiBase)
+                        .addOption(options.apiHeader)
                         .addOption(options.systemPrompt)
                         .addOption(options.userPrompt)
                         .addOption(options.promptMode)
@@ -183,7 +211,7 @@ export class Extension {
                 ).Config.tapPromise(`${ExtensionName}.${providerName}`, async (config, args) => {
                     ok(!config.auth, 'Do not store `authToken` in public config');
 
-                    const rawAuth = args.auth || readEnvAuth(providerName);
+                    const rawAuth = args.auth || readEnv(ENV_AUTH[providerName]);
                     ok(
                         rawAuth,
                         `Required param --auth is not configured for provider "${providerName}"`,
@@ -195,10 +223,17 @@ export class Extension {
                         DEFAULT_MODELS[providerName];
                     config.model = model;
 
-                    const apiBase = defined('apiBase', args, config);
+                    const apiBase =
+                        defined('apiBase', args, config) || readEnv(ENV_BASE_URL[providerName]);
                     if (apiBase) {
                         config.apiBase = apiBase;
                     }
+
+                    config.apiHeaders = parseHeaders(
+                        own<string[], 'apiHeader'>(args, 'apiHeader')
+                            ? args.apiHeader
+                            : defined('apiHeaders', config),
+                    );
 
                     if (providerName === 'yandexgpt') {
                         config.folder = defined('folder', args, config);
@@ -210,20 +245,39 @@ export class Extension {
                         );
                     }
 
-                    config.systemPrompt = resolvePromptValue(
-                        defined('systemPrompt', args, config) || undefined,
-                    );
-                    config.userPrompt = resolvePromptValue(
-                        defined('userPrompt', args, config) || undefined,
-                    );
+                    // CLI prompt paths are resolved from cwd, config values from the config dir.
+                    const systemPrompt = own<string, 'systemPrompt'>(args, 'systemPrompt')
+                        ? resolvePromptValue(args.systemPrompt)
+                        : resolvePromptValue(
+                              own<string, 'systemPrompt'>(config, 'systemPrompt')
+                                  ? config.systemPrompt
+                                  : undefined,
+                              config.resolve,
+                          );
+                    const userPrompt = own<string, 'userPrompt'>(args, 'userPrompt')
+                        ? resolvePromptValue(args.userPrompt)
+                        : resolvePromptValue(
+                              own<string, 'userPrompt'>(config, 'userPrompt')
+                                  ? config.userPrompt
+                                  : undefined,
+                              config.resolve,
+                          );
+
+                    config.systemPrompt = systemPrompt;
+                    config.userPrompt = userPrompt;
+
                     config.promptMode =
                         (defined('promptMode', args, config) as PromptMode) || 'append';
 
                     config.temperature = numberOr(defined('temperature', args, config), 0);
                     config.maxOutputTokens = intOr(defined('maxOutputTokens', args, config), 4000);
                     config.maxBatchTokens = intOr(defined('maxBatchTokens', args, config), 2000);
-                    config.maxConcurrency = intOr(defined('maxConcurrency', args, config), 5);
+                    config.maxConcurrency = Math.max(
+                        1,
+                        intOr(defined('maxConcurrency', args, config), 5),
+                    );
                     config.retry = intOr(defined('retry', args, config), 3);
+                    config.timeout = intOr(defined('timeout', args, config), DEFAULT_TIMEOUT);
 
                     let glossary: AbsolutePath | undefined;
                     if (own<string, 'glossary'>(args, 'glossary')) {

--- a/src/commands/translate/providers/ai/index.ts
+++ b/src/commands/translate/providers/ai/index.ts
@@ -3,7 +3,7 @@ import type {Translate, TranslateArgs, TranslateConfig} from '~/commands/transla
 import type {LLMClient} from './clients/types';
 import type {GlossaryPair, PromptMode} from './prompts';
 
-import {ok} from 'assert';
+import {ok} from 'node:assert';
 import {join} from 'node:path';
 
 import {getHooks as getBaseHooks} from '~/core/program';
@@ -105,9 +105,10 @@ function parseHeaders(value: unknown): Record<string, string> {
     if (Array.isArray(value)) {
         const headers: Record<string, string> = {};
         for (const entry of value) {
-            const match = String(entry).match(/^([^:]+):\s*(.*)$/);
-            ok(match, `Invalid api header "${entry}". Expected "Name: value" format.`);
-            headers[match[1].trim()] = match[2];
+            const text = String(entry);
+            const separator = text.indexOf(':');
+            ok(separator > 0, `Invalid api header "${entry}". Expected "Name: value" format.`);
+            headers[text.slice(0, separator).trim()] = text.slice(separator + 1).trim();
         }
         return headers;
     }
@@ -151,17 +152,20 @@ function numberOr(value: unknown, fallback: number): number {
 }
 
 function intOr(value: unknown, fallback: number): number {
-    if (value === null || value === undefined || value === '') {
-        return fallback;
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return Math.trunc(value);
     }
-    const n = parseInt(String(value), 10);
-    return Number.isFinite(n) ? n : fallback;
+    if (typeof value === 'string' && value !== '') {
+        const n = Number.parseInt(value, 10);
+        return Number.isFinite(n) ? n : fallback;
+    }
+    return fallback;
 }
 
 export class Extension {
     apply(program: Translate) {
         getBaseHooks(program).Command.tap(ExtensionName, (_command, opts) => {
-            const providerOption = opts.find((option) => option.flags.match('--provider'));
+            const providerOption = opts.find((option) => option.flags.includes('--provider'));
             ok(providerOption, 'Unable to configure `--provider` option.');
 
             const choices = providerOption.argChoices || [];
@@ -246,25 +250,18 @@ export class Extension {
                     }
 
                     // CLI prompt paths are resolved from cwd, config values from the config dir.
-                    const systemPrompt = own<string, 'systemPrompt'>(args, 'systemPrompt')
-                        ? resolvePromptValue(args.systemPrompt)
-                        : resolvePromptValue(
-                              own<string, 'systemPrompt'>(config, 'systemPrompt')
-                                  ? config.systemPrompt
-                                  : undefined,
-                              config.resolve,
-                          );
-                    const userPrompt = own<string, 'userPrompt'>(args, 'userPrompt')
-                        ? resolvePromptValue(args.userPrompt)
-                        : resolvePromptValue(
-                              own<string, 'userPrompt'>(config, 'userPrompt')
-                                  ? config.userPrompt
-                                  : undefined,
-                              config.resolve,
-                          );
+                    const resolvePrompt = (key: 'systemPrompt' | 'userPrompt') => {
+                        if (own<string, typeof key>(args, key)) {
+                            return resolvePromptValue(args[key]);
+                        }
+                        if (own<string, typeof key>(config, key)) {
+                            return resolvePromptValue(config[key], config.resolve);
+                        }
+                        return undefined;
+                    };
 
-                    config.systemPrompt = systemPrompt;
-                    config.userPrompt = userPrompt;
+                    config.systemPrompt = resolvePrompt('systemPrompt');
+                    config.userPrompt = resolvePrompt('userPrompt');
 
                     config.promptMode =
                         (defined('promptMode', args, config) as PromptMode) || 'append';

--- a/src/commands/translate/providers/ai/prompts.spec.ts
+++ b/src/commands/translate/providers/ai/prompts.spec.ts
@@ -1,0 +1,94 @@
+import {describe, expect, it} from 'vitest';
+
+import {DEFAULT_SYSTEM_PROMPT, FRAGMENT_SEPARATOR, buildMessages, splitFragments} from './prompts';
+
+const config = {
+    promptMode: 'append' as const,
+    sourceLanguage: 'ru',
+    targetLanguage: 'en',
+    glossaryPairs: [],
+};
+
+describe('translate ai prompts', () => {
+    describe('splitFragments', () => {
+        it('should split response by delimiter', () => {
+            const text = `One\n${FRAGMENT_SEPARATOR}\nTwo\n${FRAGMENT_SEPARATOR}\nThree`;
+
+            expect(splitFragments(text)).toEqual(['One', 'Two', 'Three']);
+        });
+
+        it('should tolerate extra whitespace around delimiter', () => {
+            const text = `One \n\n ${FRAGMENT_SEPARATOR} \n\n Two`;
+
+            expect(splitFragments(text)).toEqual(['One', 'Two']);
+        });
+
+        it('should return single fragment when delimiter is absent', () => {
+            expect(splitFragments('Just one')).toEqual(['Just one']);
+        });
+    });
+
+    describe('buildMessages', () => {
+        it('should build system and user messages with substituted placeholders', () => {
+            const [system, user] = buildMessages(['Hello'], config);
+
+            expect(system.role).toBe('system');
+            expect(system.content).toContain('from ru into en');
+            expect(user.role).toBe('user');
+            expect(user.content).toContain('Hello');
+            expect(user.content).toContain(FRAGMENT_SEPARATOR);
+        });
+
+        it('should append custom system prompt to the default one', () => {
+            const [system] = buildMessages(['Hello'], {
+                ...config,
+                systemPrompt: 'Prefer formal tone.',
+            });
+
+            expect(system.content).toContain('professional technical documentation translator');
+            expect(system.content).toContain('Prefer formal tone.');
+        });
+
+        it('should replace the default system prompt in replace mode', () => {
+            const [system] = buildMessages(['Hello'], {
+                ...config,
+                systemPrompt: 'Custom only.',
+                promptMode: 'replace',
+            });
+
+            expect(system.content).toBe('Custom only.');
+        });
+
+        it('should fall back to the default system prompt in replace mode without custom prompt', () => {
+            const [system] = buildMessages(['Hello'], {
+                ...config,
+                promptMode: 'replace',
+            });
+
+            expect(system.content).not.toContain('{{source}}');
+            expect(system.content).toContain(DEFAULT_SYSTEM_PROMPT.split('\n')[0]);
+        });
+
+        it('should render glossary pairs into the user message', () => {
+            const [, user] = buildMessages(['Hello'], {
+                ...config,
+                glossaryPairs: [{sourceText: 'облако', translatedText: 'cloud'}],
+            });
+
+            expect(user.content).toContain('облако');
+            expect(user.content).toContain('cloud');
+        });
+
+        it('should join fragments with the delimiter', () => {
+            const [, user] = buildMessages(['One', 'Two'], config);
+
+            expect(user.content).toContain(`One\n${FRAGMENT_SEPARATOR}\nTwo`);
+        });
+
+        it('should not substitute placeholders inside fragment content', () => {
+            const [, user] = buildMessages(['Value of {{source}} var'], config);
+
+            expect(user.content).toContain('Value of {{source}} var');
+        });
+    });
+});

--- a/src/commands/translate/providers/ai/prompts.ts
+++ b/src/commands/translate/providers/ai/prompts.ts
@@ -1,0 +1,127 @@
+import {existsSync, readFileSync} from 'node:fs';
+import {dedent} from 'ts-dedent';
+
+import type {ChatMessage} from './clients/types';
+
+export type PromptMode = 'append' | 'replace';
+
+export type GlossaryPair = {sourceText: string; translatedText: string};
+
+export type PromptConfig = {
+    systemPrompt?: string;
+    userPrompt?: string;
+    promptMode: PromptMode;
+    sourceLanguage: string;
+    targetLanguage: string;
+    glossaryPairs: GlossaryPair[];
+};
+
+const FRAGMENT_SEPARATOR = '<<<§§§>>>';
+
+export const DEFAULT_SYSTEM_PROMPT = dedent`
+    You are a professional technical documentation translator.
+    Translate the supplied fragments from {{source}} into {{target}}.
+
+    Strict rules:
+    - Preserve all Markdown syntax, HTML tags, code blocks, inline code, links, images and Liquid/YFM directives exactly as they appear.
+    - Do not translate code, identifiers, file paths, URLs, or text inside <code> or fenced code blocks.
+    - Do not add explanations, prefaces, or trailing notes — return translations only.
+    - Keep the same number of fragments and their original order.
+    - Each fragment is delimited by the line "${FRAGMENT_SEPARATOR}". Keep this exact delimiter between fragments in your output.
+    - If a fragment is empty or contains only formatting, return it unchanged.
+`;
+
+export const DEFAULT_USER_PROMPT = dedent`
+    Translate the following fragments from {{source}} into {{target}}.
+    Return the translated fragments in the same order, separated by the exact delimiter line "{{separator}}".
+
+    {{glossary}}
+
+    {{fragments}}
+`;
+
+export {FRAGMENT_SEPARATOR};
+
+/**
+ * Resolves a prompt value: if it is an existing file path, read it; otherwise use as-is.
+ */
+export function resolvePromptValue(value: string | undefined): string | undefined {
+    if (!value) {
+        return undefined;
+    }
+
+    const trimmed = value.trim();
+    if (existsSync(trimmed)) {
+        return readFileSync(trimmed, 'utf8');
+    }
+
+    return value;
+}
+
+function applyVars(template: string, vars: Record<string, string>): string {
+    return template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+        return key in vars ? vars[key] : match;
+    });
+}
+
+function renderGlossary(pairs: GlossaryPair[]): string {
+    if (!pairs.length) {
+        return '';
+    }
+    const lines = pairs.map(({sourceText, translatedText}) => `- ${sourceText} → ${translatedText}`);
+    return `Use these required term translations:\n${lines.join('\n')}\n`;
+}
+
+function joinFragments(fragments: string[]): string {
+    return fragments.join(`\n${FRAGMENT_SEPARATOR}\n`);
+}
+
+function escapeRegExp(value: string) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Splits an LLM response back into fragments using the delimiter.
+ */
+export function splitFragments(text: string): string[] {
+    const delimiter = new RegExp(`\\s*\\n?${escapeRegExp(FRAGMENT_SEPARATOR)}\\n?\\s*`, 'g');
+    return text.split(delimiter).map((part) => part.replace(/^\n+|\n+$/g, ''));
+}
+
+/**
+ * Builds chat messages for a batch of fragments.
+ *
+ * `promptMode`:
+ *  - `append` (default): combines the default system prompt with the user-provided system prompt.
+ *  - `replace`: the user-provided system prompt fully replaces the default.
+ */
+export function buildMessages(fragments: string[], config: PromptConfig): ChatMessage[] {
+    const {systemPrompt, userPrompt, promptMode, sourceLanguage, targetLanguage, glossaryPairs} =
+        config;
+
+    const vars = {
+        source: sourceLanguage,
+        target: targetLanguage,
+        glossary: renderGlossary(glossaryPairs),
+        separator: FRAGMENT_SEPARATOR,
+        fragments: joinFragments(fragments),
+        text: joinFragments(fragments),
+    };
+
+    let system: string;
+    if (promptMode === 'replace' && systemPrompt) {
+        system = applyVars(systemPrompt, vars);
+    } else if (systemPrompt) {
+        system = applyVars(DEFAULT_SYSTEM_PROMPT, vars) + '\n\n' + applyVars(systemPrompt, vars);
+    } else {
+        system = applyVars(DEFAULT_SYSTEM_PROMPT, vars);
+    }
+
+    const userTemplate = userPrompt || DEFAULT_USER_PROMPT;
+    const user = applyVars(userTemplate, vars);
+
+    return [
+        {role: 'system', content: system},
+        {role: 'user', content: user},
+    ];
+}

--- a/src/commands/translate/providers/ai/prompts.ts
+++ b/src/commands/translate/providers/ai/prompts.ts
@@ -1,7 +1,9 @@
+import type {ChatMessage} from './clients/types';
+
 import {existsSync, readFileSync} from 'node:fs';
 import {dedent} from 'ts-dedent';
 
-import type {ChatMessage} from './clients/types';
+import {escapeRegExp} from './utils';
 
 export type PromptMode = 'append' | 'replace';
 
@@ -68,7 +70,9 @@ function renderGlossary(pairs: GlossaryPair[]): string {
     if (!pairs.length) {
         return '';
     }
-    const lines = pairs.map(({sourceText, translatedText}) => `- ${sourceText} → ${translatedText}`);
+    const lines = pairs.map(
+        ({sourceText, translatedText}) => `- ${sourceText} → ${translatedText}`,
+    );
     return `Use these required term translations:\n${lines.join('\n')}\n`;
 }
 
@@ -76,15 +80,11 @@ function joinFragments(fragments: string[]): string {
     return fragments.join(`\n${FRAGMENT_SEPARATOR}\n`);
 }
 
-function escapeRegExp(value: string) {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 /**
  * Splits an LLM response back into fragments using the delimiter.
  */
 export function splitFragments(text: string): string[] {
-    const delimiter = new RegExp(`\\s*\\n?${escapeRegExp(FRAGMENT_SEPARATOR)}\\n?\\s*`, 'g');
+    const delimiter = new RegExp(`\\s*${escapeRegExp(FRAGMENT_SEPARATOR)}\\s*`, 'g');
     return text.split(delimiter).map((part) => part.replace(/^\n+|\n+$/g, ''));
 }
 
@@ -99,13 +99,14 @@ export function buildMessages(fragments: string[], config: PromptConfig): ChatMe
     const {systemPrompt, userPrompt, promptMode, sourceLanguage, targetLanguage, glossaryPairs} =
         config;
 
+    const joined = joinFragments(fragments);
     const vars = {
         source: sourceLanguage,
         target: targetLanguage,
         glossary: renderGlossary(glossaryPairs),
         separator: FRAGMENT_SEPARATOR,
-        fragments: joinFragments(fragments),
-        text: joinFragments(fragments),
+        fragments: joined,
+        text: joined,
     };
 
     let system: string;

--- a/src/commands/translate/providers/ai/prompts.ts
+++ b/src/commands/translate/providers/ai/prompts.ts
@@ -1,9 +1,8 @@
 import type {ChatMessage} from './clients/types';
 
 import {existsSync, readFileSync} from 'node:fs';
+import {escapeRegExp} from 'lodash';
 import {dedent} from 'ts-dedent';
-
-import {escapeRegExp} from './utils';
 
 export type PromptMode = 'append' | 'replace';
 
@@ -46,15 +45,30 @@ export {FRAGMENT_SEPARATOR};
 
 /**
  * Resolves a prompt value: if it is an existing file path, read it; otherwise use as-is.
+ * The optional `resolve` callback maps config-relative paths to absolute ones.
  */
-export function resolvePromptValue(value: string | undefined): string | undefined {
+export function resolvePromptValue(
+    value: string | undefined,
+    resolve?: (path: string) => string,
+): string | undefined {
     if (!value) {
         return undefined;
     }
 
     const trimmed = value.trim();
-    if (existsSync(trimmed)) {
-        return readFileSync(trimmed, 'utf8');
+
+    // A real file path never contains a line break.
+    if (!trimmed.includes('\n')) {
+        if (existsSync(trimmed)) {
+            return readFileSync(trimmed, 'utf8');
+        }
+
+        if (resolve) {
+            const resolved = resolve(trimmed);
+            if (existsSync(resolved)) {
+                return readFileSync(resolved, 'utf8');
+            }
+        }
     }
 
     return value;

--- a/src/commands/translate/providers/ai/prompts.ts
+++ b/src/commands/translate/providers/ai/prompts.ts
@@ -1,7 +1,6 @@
 import type {ChatMessage} from './clients/types';
 
 import {existsSync, readFileSync} from 'node:fs';
-import {escapeRegExp} from 'lodash';
 import {dedent} from 'ts-dedent';
 
 export type PromptMode = 'append' | 'replace';
@@ -98,8 +97,7 @@ function joinFragments(fragments: string[]): string {
  * Splits an LLM response back into fragments using the delimiter.
  */
 export function splitFragments(text: string): string[] {
-    const delimiter = new RegExp(`\\s*${escapeRegExp(FRAGMENT_SEPARATOR)}\\s*`, 'g');
-    return text.split(delimiter).map((part) => part.replace(/^\n+|\n+$/g, ''));
+    return text.split(FRAGMENT_SEPARATOR).map((part) => part.trim());
 }
 
 /**

--- a/src/commands/translate/providers/ai/provider.spec.ts
+++ b/src/commands/translate/providers/ai/provider.spec.ts
@@ -1,0 +1,164 @@
+import type {Logger} from '~/core/logger';
+import type {AITranslationConfig} from './index';
+import type {LLMClient} from './clients/types';
+import type {Defer} from './utils';
+
+import {describe, expect, it, vi} from 'vitest';
+
+import {makeTranslator} from './provider';
+import {FRAGMENT_SEPARATOR, splitFragments} from './prompts';
+import {LLMAuthError} from './utils';
+
+type FakeComplete = (fragments: string[], call: number) => string[] | Error;
+
+// The `{{fragments}}` user prompt makes the user message contain exactly
+// the joined fragments, so the fake client can parse them back.
+function makeClient(complete: FakeComplete) {
+    let call = 0;
+
+    const client: LLMClient = {
+        name: 'fake',
+        complete: vi.fn(async (messages) => {
+            const fragments = splitFragments(messages[messages.length - 1].content);
+            const result = complete(fragments, call++);
+
+            if (result instanceof Error) {
+                throw result;
+            }
+
+            return {text: result.join(`\n${FRAGMENT_SEPARATOR}\n`)};
+        }),
+    };
+
+    return client;
+}
+
+function makeParams(client: LLMClient, config: Partial<AITranslationConfig> = {}) {
+    const warn = vi.fn();
+    const stat = {inputTokens: 0, outputTokens: 0, requests: 0, bytes: 0};
+    const cache = new Map<string, Defer>();
+
+    return {
+        params: {
+            client,
+            config: {
+                userPrompt: '{{fragments}}',
+                promptMode: 'append',
+                glossaryPairs: [],
+                temperature: 0,
+                maxOutputTokens: 100,
+                maxBatchTokens: 20,
+                maxConcurrency: 2,
+                retry: 0,
+                dryRun: false,
+                ...config,
+            } as AITranslationConfig,
+            sourceLanguage: 'ru',
+            targetLanguage: 'en',
+            cache,
+            stat,
+            logger: {warn} as unknown as Logger,
+        },
+        warn,
+        stat,
+        cache,
+    };
+}
+
+const translated = (fragments: string[]) => fragments.map((text) => `T:${text}`);
+
+describe('translate ai provider', () => {
+    describe('makeTranslator', () => {
+        it('should translate texts through the client', async () => {
+            const client = makeClient(translated);
+            const {params} = makeParams(client);
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', ['One', 'Two']);
+
+            expect(result).toEqual(['T:One', 'T:Two']);
+            expect(client.complete).toHaveBeenCalledTimes(1);
+        });
+
+        it('should split batches by token budget', async () => {
+            const client = makeClient(translated);
+            // ~10 tokens each with a 15 tokens budget - one text per batch.
+            const {params} = makeParams(client, {maxBatchTokens: 15});
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', ['a'.repeat(40), 'b'.repeat(40)]);
+
+            expect(result).toEqual(['T:' + 'a'.repeat(40), 'T:' + 'b'.repeat(40)]);
+            expect(client.complete).toHaveBeenCalledTimes(2);
+        });
+
+        it('should dedupe repeated units via cache', async () => {
+            const client = makeClient(translated);
+            const {params} = makeParams(client);
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', ['Same', 'Same', 'Other']);
+
+            expect(result).toEqual(['T:Same', 'T:Same', 'T:Other']);
+            expect(client.complete).toHaveBeenCalledTimes(1);
+
+            const again = await translate('other.md', ['Same']);
+
+            expect(again).toEqual(['T:Same']);
+            expect(client.complete).toHaveBeenCalledTimes(1);
+        });
+
+        it('should retry one-by-one when fragment count mismatches', async () => {
+            const client = makeClient((fragments, call) => {
+                // First (batched) response merges everything into one fragment.
+                if (call === 0) {
+                    return ['merged'];
+                }
+                return translated(fragments);
+            });
+            const {params, warn} = makeParams(client);
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', ['One', 'Two']);
+
+            expect(result).toEqual(['T:One', 'T:Two']);
+            expect(client.complete).toHaveBeenCalledTimes(3);
+            expect(warn).toHaveBeenCalledWith('file.md', expect.stringContaining('one-by-one'));
+        });
+
+        it('should reject and evict cached defers when the batch fails', async () => {
+            const client = makeClient(() => new LLMAuthError('denied'));
+            const {params, cache} = makeParams(client);
+            const translate = makeTranslator(params);
+
+            await expect(translate('file.md', ['One', 'Two'])).rejects.toThrow('denied');
+            expect(cache.size).toBe(0);
+        });
+
+        it('should skip oversized units and keep source text', async () => {
+            const client = makeClient(translated);
+            const {params, warn} = makeParams(client, {maxBatchTokens: 5});
+            const translate = makeTranslator(params);
+
+            const oversized = 'x'.repeat(100);
+            const result = await translate('file.md', [oversized]);
+
+            expect(result).toEqual([oversized]);
+            expect(client.complete).not.toHaveBeenCalled();
+            expect(warn).toHaveBeenCalledWith('file.md', expect.stringContaining('too big'));
+        });
+
+        it('should estimate usage without client calls on dry run', async () => {
+            const client = makeClient(translated);
+            const {params, stat} = makeParams(client, {dryRun: true});
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', ['One', 'Two']);
+
+            expect(result).toEqual(['One', 'Two']);
+            expect(client.complete).not.toHaveBeenCalled();
+            expect(stat.requests).toBe(1);
+            expect(stat.inputTokens).toBeGreaterThan(0);
+        });
+    });
+});

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -1,0 +1,354 @@
+import type {Logger} from '~/core/logger';
+import type {TranslateConfig} from '~/commands/translate';
+import type {AITranslationConfig} from './index';
+import type {LLMClient} from './clients/types';
+
+import {extname, join, resolve} from 'node:path';
+import {asyncify, eachLimit} from 'async';
+import liquid from '@diplodoc/transform/lib/liquid';
+
+import {LogLevel} from '~/core/logger';
+
+import {FileLoader, TranslateError, compose, extract, resolveSchemas} from '../../utils';
+import {TranslateLogger} from '../../logger';
+
+import {Defer, backoff, bytes, estimateTokens, wait} from './utils';
+import {LLMResponseError} from './utils/errors';
+import {buildMessages, splitFragments} from './prompts';
+
+const onFatalError = () => {
+    process.exit(1);
+};
+
+type AITranslateConfig = TranslateConfig & AITranslationConfig;
+
+export type ClientFactory = (config: AITranslateConfig) => LLMClient;
+
+export class Provider {
+    readonly logger: TranslateLogger;
+
+    private readonly clientFactory: ClientFactory;
+
+    constructor(clientFactory: ClientFactory, config: TranslateConfig) {
+        this.clientFactory = clientFactory;
+        this.logger = new TranslateLogger(config);
+    }
+
+    pipe(logger: Logger) {
+        this.logger.pipe(logger);
+    }
+
+    async skip(skipped: [string, string][]) {
+        this.logger.skipped(skipped);
+    }
+
+    async translate(files: string[], config: AITranslateConfig) {
+        const client = this.clientFactory(config);
+        const {input, output, source, target: targets, vars, dryRun, maxConcurrency} = config;
+
+        try {
+            for (const target of targets) {
+                const cache = new Map<string, Defer>();
+                const stat = {inputTokens: 0, outputTokens: 0, requests: 0, bytes: 0};
+
+                const translate = makeTranslator({
+                    client,
+                    config,
+                    sourceLanguage: source.language,
+                    targetLanguage: target.language,
+                    cache,
+                    stat,
+                    logger: this.logger,
+                });
+
+                const process = makeProcessor({
+                    input,
+                    output,
+                    sourceLanguage: source.language,
+                    targetLanguage: target.language,
+                    vars,
+                    translate,
+                });
+
+                await eachLimit(
+                    files,
+                    maxConcurrency,
+                    asyncify(async (file: string) => {
+                        try {
+                            this.logger.translate(file);
+                            await process(file);
+                            if (!dryRun) {
+                                this.logger.translated(file);
+                            }
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        } catch (error: any) {
+                            if (error instanceof TranslateError) {
+                                this.logger.error(file, `${error.message}`, error.code);
+                                if (error.fatal) {
+                                    onFatalError();
+                                }
+                            } else {
+                                this.logger.error(file, error.message);
+                            }
+                        }
+                    }),
+                );
+
+                this.logger.stat(
+                    `requests: ${stat.requests} input-tokens: ${stat.inputTokens} ` +
+                        `output-tokens: ${stat.outputTokens} bytes: ${stat.bytes}`,
+                );
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+            if (error instanceof TranslateError) {
+                this.logger.topic(LogLevel.ERROR, error.code)(error.message);
+            } else {
+                this.logger.error(error);
+            }
+            process.exit(1);
+        }
+    }
+}
+
+type ProcessorParams = {
+    input: string;
+    output: string;
+    sourceLanguage: string;
+    targetLanguage: string;
+    vars: Hash;
+    translate: Translate;
+};
+
+type Translate = (path: string, texts: string[]) => Promise<string[]>;
+
+function makeProcessor(params: ProcessorParams) {
+    const {input, output, sourceLanguage, targetLanguage, vars, translate} = params;
+    const inputRoot = resolve(input);
+    const outputRoot = resolve(output);
+
+    return async function (path: string) {
+        const ext = extname(path);
+        if (!['.yaml', '.md'].includes(ext)) {
+            return;
+        }
+
+        const inputPath = join(inputRoot, path);
+        const outputPath = (path: string) =>
+            join(
+                outputRoot,
+                path
+                    .replace(inputRoot, '')
+                    .replace('/' + sourceLanguage + '/', '/' + targetLanguage + '/'),
+            );
+
+        const content = new FileLoader(inputPath);
+        await content.load();
+
+        if (Object.keys(vars).length && content.isString) {
+            content.set(
+                liquid(content.data as string, vars, inputPath, {
+                    conditions: 'strict',
+                    substitutions: false,
+                    cycles: false,
+                }),
+            );
+        }
+
+        if (!content.data) {
+            await content.dump(outputPath);
+            return;
+        }
+
+        const {schemas, ajvOptions} = await resolveSchemas({content: content.data, path});
+        const {units, skeleton} = extract(content.data, {
+            compact: true,
+            source: {language: sourceLanguage, locale: 'RU'},
+            target: {language: targetLanguage, locale: 'US'},
+            schemas,
+            ajvOptions,
+        });
+
+        if (!units.length) {
+            await content.dump(outputPath);
+            return;
+        }
+
+        const parts = await translate(path, units);
+
+        content.set(compose(skeleton, parts, {useSource: true, schemas, ajvOptions}));
+        await content.dump(outputPath);
+    };
+}
+
+type TranslatorParams = {
+    client: LLMClient;
+    config: AITranslateConfig;
+    sourceLanguage: string;
+    targetLanguage: string;
+    cache: Map<string, Defer>;
+    stat: {inputTokens: number; outputTokens: number; requests: number; bytes: number};
+    logger: Logger;
+};
+
+function makeTranslator(params: TranslatorParams): Translate {
+    const {client, config, sourceLanguage, targetLanguage, cache, stat, logger} = params;
+    const {
+        systemPrompt,
+        userPrompt,
+        promptMode,
+        glossaryPairs,
+        temperature,
+        maxOutputTokens,
+        maxBatchTokens,
+        maxConcurrency,
+        retry,
+        dryRun,
+    } = config;
+
+    const schedule = scheduler(maxConcurrency);
+
+    async function translateBatch(fragments: string[]): Promise<string[]> {
+        if (!fragments.length) {
+            return [];
+        }
+
+        const messages = buildMessages(fragments, {
+            systemPrompt,
+            userPrompt,
+            promptMode,
+            sourceLanguage,
+            targetLanguage,
+            glossaryPairs,
+        });
+
+        if (dryRun) {
+            const inputTokens = messages.reduce((sum, m) => sum + estimateTokens(m.content), 0);
+            stat.inputTokens += inputTokens;
+            stat.outputTokens += fragments.reduce((sum, f) => sum + estimateTokens(f), 0);
+            stat.requests++;
+            stat.bytes += bytes(fragments);
+            return fragments;
+        }
+
+        const result = await backoff(
+            () => client.complete(messages, {temperature, maxTokens: maxOutputTokens}),
+            retry,
+        );
+
+        stat.requests++;
+        stat.bytes += bytes(fragments);
+        if (result.usage) {
+            stat.inputTokens += result.usage.inputTokens;
+            stat.outputTokens += result.usage.outputTokens;
+        }
+
+        const parts = splitFragments(result.text);
+
+        if (parts.length !== fragments.length) {
+            throw new LLMResponseError(
+                `Expected ${fragments.length} fragments in LLM response, got ${parts.length}`,
+            );
+        }
+
+        return parts;
+    }
+
+    async function translateWithFallback(fragments: string[]): Promise<string[]> {
+        try {
+            return await translateBatch(fragments);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+            if (error instanceof LLMResponseError && fragments.length > 1) {
+                logger.warn(
+                    `Batch of ${fragments.length} fragments failed (${error.message}); retrying one-by-one.`,
+                );
+                const result: string[] = [];
+                for (const fragment of fragments) {
+                    const single = await translateBatch([fragment]);
+                    result.push(single[0]);
+                }
+                return result;
+            }
+            throw error;
+        }
+    }
+
+    return async function translate(_path: string, texts: string[]) {
+        const promises: Promise<string>[] = [];
+        const requests: Promise<void>[] = [];
+        let buffer: string[] = [];
+        let bufferTokens = 0;
+
+        const release = () => {
+            if (!buffer.length) {
+                return;
+            }
+            const batch = buffer;
+            requests.push(
+                schedule(async () => {
+                    const translated = await translateWithFallback(batch);
+                    translated.forEach((text, i) => {
+                        cache.get(batch[i])?.resolve(text);
+                    });
+                }),
+            );
+            buffer = [];
+            bufferTokens = 0;
+        };
+
+        for (const text of texts) {
+            const tokens = estimateTokens(text);
+
+            if (cache.has(text)) {
+                promises.push(cache.get(text)!.promise);
+                continue;
+            }
+
+            const defer = new Defer();
+            cache.set(text, defer);
+            promises.push(defer.promise);
+
+            if (bufferTokens + tokens > maxBatchTokens && buffer.length) {
+                release();
+            }
+            buffer.push(text);
+            bufferTokens += tokens;
+        }
+
+        release();
+
+        await Promise.all(requests);
+
+        return Promise.all(promises);
+    };
+}
+
+function scheduler(limit: number) {
+    let active = 0;
+    const queue: (() => void)[] = [];
+
+    const next = () => {
+        if (active >= limit) {
+            return;
+        }
+        const task = queue.shift();
+        if (task) {
+            task();
+        }
+    };
+
+    return async function <T>(action: () => Promise<T>): Promise<T> {
+        if (active >= limit) {
+            await new Promise<void>((resolve) => queue.push(resolve));
+        }
+        active++;
+        try {
+            return await action();
+        } finally {
+            active--;
+            await wait(0);
+            next();
+        }
+    };
+}

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -12,8 +12,7 @@ import {LogLevel} from '~/core/logger';
 import {FileLoader, TranslateError, compose, extract, resolveSchemas} from '../../utils';
 import {TranslateLogger} from '../../logger';
 
-import {Defer, backoff, bytes, estimateTokens, wait} from './utils';
-import {LLMResponseError} from './utils/errors';
+import {Defer, LLMResponseError, backoff, bytes, estimateTokens} from './utils';
 import {buildMessages, splitFragments} from './prompts';
 
 const onFatalError = () => {
@@ -254,13 +253,14 @@ function makeTranslator(params: TranslatorParams): Translate {
         return parts;
     }
 
-    async function translateWithFallback(fragments: string[]): Promise<string[]> {
+    async function translateWithFallback(path: string, fragments: string[]): Promise<string[]> {
         try {
             return await translateBatch(fragments);
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
             if (error instanceof LLMResponseError && fragments.length > 1) {
                 logger.warn(
+                    path,
                     `Batch of ${fragments.length} fragments failed (${error.message}); retrying one-by-one.`,
                 );
                 const result: string[] = [];
@@ -274,7 +274,7 @@ function makeTranslator(params: TranslatorParams): Translate {
         }
     }
 
-    return async function translate(_path: string, texts: string[]) {
+    return async function translate(path: string, texts: string[]) {
         const promises: Promise<string>[] = [];
         const requests: Promise<void>[] = [];
         let buffer: string[] = [];
@@ -287,10 +287,23 @@ function makeTranslator(params: TranslatorParams): Translate {
             const batch = buffer;
             requests.push(
                 schedule(async () => {
-                    const translated = await translateWithFallback(batch);
-                    translated.forEach((text, i) => {
-                        cache.get(batch[i])?.resolve(text);
-                    });
+                    try {
+                        const translated = await translateWithFallback(path, batch);
+                        translated.forEach((text, i) => {
+                            cache.get(batch[i])?.resolve(text);
+                        });
+                    } catch (error) {
+                        // Reject and evict pending defers, otherwise files sharing
+                        // the same units would await them forever.
+                        for (const text of batch) {
+                            const defer = cache.get(text);
+                            if (defer) {
+                                cache.delete(text);
+                                defer.promise.catch(() => {});
+                                defer.reject(error);
+                            }
+                        }
+                    }
                 }),
             );
             buffer = [];
@@ -300,8 +313,9 @@ function makeTranslator(params: TranslatorParams): Translate {
         for (const text of texts) {
             const tokens = estimateTokens(text);
 
-            if (cache.has(text)) {
-                promises.push(cache.get(text)!.promise);
+            const cached = cache.get(text);
+            if (cached) {
+                promises.push(cached.promise);
                 continue;
             }
 
@@ -328,26 +342,27 @@ function scheduler(limit: number) {
     let active = 0;
     const queue: (() => void)[] = [];
 
+    // Passes the freed slot directly to the next queued task,
+    // so `active` never exceeds `limit`.
     const next = () => {
-        if (active >= limit) {
-            return;
-        }
         const task = queue.shift();
         if (task) {
             task();
+        } else {
+            active--;
         }
     };
 
     return async function <T>(action: () => Promise<T>): Promise<T> {
         if (active >= limit) {
             await new Promise<void>((resolve) => queue.push(resolve));
+        } else {
+            active++;
         }
-        active++;
+
         try {
             return await action();
         } finally {
-            active--;
-            await wait(0);
             next();
         }
     };

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -19,9 +19,7 @@ const onFatalError = () => {
     process.exit(1);
 };
 
-type AITranslateConfig = TranslateConfig & AITranslationConfig;
-
-export type ClientFactory = (config: AITranslateConfig) => LLMClient;
+export type ClientFactory = (config: AITranslationConfig) => LLMClient;
 
 export class Provider {
     readonly logger: TranslateLogger;
@@ -41,7 +39,7 @@ export class Provider {
         this.logger.skipped(skipped);
     }
 
-    async translate(files: string[], config: AITranslateConfig) {
+    async translate(files: string[], config: AITranslationConfig) {
         const client = this.clientFactory(config);
         const {input, output, source, target: targets, vars, dryRun, maxConcurrency} = config;
 
@@ -60,7 +58,7 @@ export class Provider {
                     logger: this.logger,
                 });
 
-                const process = makeProcessor({
+                const processFile = makeProcessor({
                     input,
                     output,
                     sourceLanguage: source.language,
@@ -75,7 +73,7 @@ export class Provider {
                     asyncify(async (file: string) => {
                         try {
                             this.logger.translate(file);
-                            await process(file);
+                            await processFile(file);
                             if (!dryRun) {
                                 this.logger.translated(file);
                             }
@@ -182,7 +180,7 @@ function makeProcessor(params: ProcessorParams) {
 
 type TranslatorParams = {
     client: LLMClient;
-    config: AITranslateConfig;
+    config: AITranslationConfig;
     sourceLanguage: string;
     targetLanguage: string;
     cache: Map<string, Defer>;
@@ -190,7 +188,7 @@ type TranslatorParams = {
     logger: Logger;
 };
 
-function makeTranslator(params: TranslatorParams): Translate {
+export function makeTranslator(params: TranslatorParams): Translate {
     const {client, config, sourceLanguage, targetLanguage, cache, stat, logger} = params;
     const {
         systemPrompt,
@@ -312,6 +310,15 @@ function makeTranslator(params: TranslatorParams): Translate {
 
         for (const text of texts) {
             const tokens = estimateTokens(text);
+
+            if (tokens > maxBatchTokens) {
+                logger.warn(
+                    path,
+                    `Skip document part for translation. Part is too big (~${tokens} tokens > ${maxBatchTokens}).`,
+                );
+                promises.push(Promise.resolve(text));
+                continue;
+            }
 
             const cached = cache.get(text);
             if (cached) {

--- a/src/commands/translate/providers/ai/utils/errors.spec.ts
+++ b/src/commands/translate/providers/ai/utils/errors.spec.ts
@@ -1,0 +1,91 @@
+import {describe, expect, it} from 'vitest';
+import {AxiosError} from 'axios';
+
+import {
+    LLMAuthError,
+    LLMRateLimitError,
+    LLMRequestError,
+    LLMResponseError,
+    throwLLMError,
+} from './errors';
+
+function axiosError(status: number, data: unknown = {}, headers: Record<string, string> = {}) {
+    const error = new AxiosError('Request failed');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    error.response = {status, statusText: `HTTP ${status}`, data, headers} as any;
+    return error;
+}
+
+describe('translate ai errors', () => {
+    describe('throwLLMError', () => {
+        it('should map 401 to auth error', () => {
+            expect(() => throwLLMError(axiosError(401), 'test')).toThrow(LLMAuthError);
+        });
+
+        it('should map 403 to auth error', () => {
+            expect(() => throwLLMError(axiosError(403), 'test')).toThrow(LLMAuthError);
+        });
+
+        it('should map 429 to rate limit error with retry-after', () => {
+            try {
+                throwLLMError(axiosError(429, {}, {'retry-after': '7'}), 'test');
+                expect.unreachable();
+            } catch (error) {
+                expect(error).toBeInstanceOf(LLMRateLimitError);
+                expect((error as LLMRateLimitError).retryAfter).toBe(7);
+                expect((error as LLMRateLimitError).retryable).toBe(true);
+            }
+        });
+
+        it('should map 429 without retry-after header', () => {
+            try {
+                throwLLMError(axiosError(429), 'test');
+                expect.unreachable();
+            } catch (error) {
+                expect((error as LLMRateLimitError).retryAfter).toBeUndefined();
+            }
+        });
+
+        it('should mark 5xx as retryable request error', () => {
+            try {
+                throwLLMError(axiosError(503), 'test');
+                expect.unreachable();
+            } catch (error) {
+                expect(error).toBeInstanceOf(LLMRequestError);
+                expect((error as LLMRequestError).retryable).toBe(true);
+            }
+        });
+
+        it('should mark 4xx as non-retryable request error', () => {
+            try {
+                throwLLMError(axiosError(400), 'test');
+                expect.unreachable();
+            } catch (error) {
+                expect(error).toBeInstanceOf(LLMRequestError);
+                expect((error as LLMRequestError).retryable).toBe(false);
+            }
+        });
+
+        it('should extract provider error message from response body', () => {
+            expect(() =>
+                throwLLMError(axiosError(400, {error: {message: 'bad model'}}), 'test'),
+            ).toThrow('bad model');
+        });
+
+        it('should mark network errors without response as retryable', () => {
+            try {
+                throwLLMError(new AxiosError('socket hang up'), 'test');
+                expect.unreachable();
+            } catch (error) {
+                expect(error).toBeInstanceOf(LLMRequestError);
+                expect((error as LLMRequestError).retryable).toBe(true);
+                expect((error as LLMRequestError).message).toBe('socket hang up');
+            }
+        });
+
+        it('should rethrow non-axios errors as is', () => {
+            const original = new LLMResponseError('broken');
+            expect(() => throwLLMError(original, 'test')).toThrow(original);
+        });
+    });
+});

--- a/src/commands/translate/providers/ai/utils/errors.ts
+++ b/src/commands/translate/providers/ai/utils/errors.ts
@@ -1,0 +1,40 @@
+import {TranslateError} from '../../../utils';
+
+export class LLMRequestError extends TranslateError {
+    status: number;
+
+    retryable: boolean;
+
+    constructor(
+        status: number,
+        message: string,
+        info: {fatal?: boolean; retryable?: boolean} = {},
+    ) {
+        super(message, 'LLM_REQUEST_ERROR', info.fatal);
+        this.status = status;
+        this.retryable = info.retryable ?? false;
+    }
+}
+
+export class LLMAuthError extends TranslateError {
+    constructor(message: string) {
+        super(message, 'LLM_AUTH_ERROR', true);
+    }
+}
+
+export class LLMRateLimitError extends TranslateError {
+    retryable = true;
+
+    constructor(message: string) {
+        super(message, 'LLM_RATE_LIMIT');
+    }
+}
+
+export class LLMResponseError extends TranslateError {
+    retryable: boolean;
+
+    constructor(message: string, retryable = true) {
+        super(message, 'LLM_RESPONSE_ERROR');
+        this.retryable = retryable;
+    }
+}

--- a/src/commands/translate/providers/ai/utils/errors.ts
+++ b/src/commands/translate/providers/ai/utils/errors.ts
@@ -1,3 +1,5 @@
+import {AxiosError} from 'axios';
+
 import {TranslateError} from '../../../utils';
 
 export class LLMRequestError extends TranslateError {
@@ -37,4 +39,34 @@ export class LLMResponseError extends TranslateError {
         super(message, 'LLM_RESPONSE_ERROR');
         this.retryable = retryable;
     }
+}
+
+/**
+ * Maps an axios error to the corresponding LLM error.
+ * Rethrows unknown errors as is.
+ */
+export function throwLLMError(error: unknown, provider: string): never {
+    if (error instanceof AxiosError) {
+        const {response} = error;
+
+        if (response) {
+            const {status, statusText, data} = response;
+            const message = data?.error?.message || data?.message || statusText;
+
+            if (status === 401 || status === 403) {
+                throw new LLMAuthError(`${provider} auth failed: ${message}`);
+            }
+            if (status === 429) {
+                throw new LLMRateLimitError(message);
+            }
+            throw new LLMRequestError(status, message, {
+                retryable: status >= 500 && status < 600,
+            });
+        }
+
+        // No response received (timeout, connection reset) - worth retrying.
+        throw new LLMRequestError(0, error.message, {retryable: true});
+    }
+
+    throw error;
 }

--- a/src/commands/translate/providers/ai/utils/errors.ts
+++ b/src/commands/translate/providers/ai/utils/errors.ts
@@ -27,8 +27,12 @@ export class LLMAuthError extends TranslateError {
 export class LLMRateLimitError extends TranslateError {
     retryable = true;
 
-    constructor(message: string) {
+    /** Server-suggested pause in seconds (Retry-After header). */
+    retryAfter?: number;
+
+    constructor(message: string, retryAfter?: number) {
         super(message, 'LLM_RATE_LIMIT');
+        this.retryAfter = retryAfter;
     }
 }
 
@@ -57,7 +61,11 @@ export function throwLLMError(error: unknown, provider: string): never {
                 throw new LLMAuthError(`${provider} auth failed: ${message}`);
             }
             if (status === 429) {
-                throw new LLMRateLimitError(message);
+                const retryAfter = Number(response.headers?.['retry-after']);
+                throw new LLMRateLimitError(
+                    message,
+                    Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter : undefined,
+                );
             }
             throw new LLMRequestError(status, message, {
                 retryable: status >= 500 && status < 600,

--- a/src/commands/translate/providers/ai/utils/index.spec.ts
+++ b/src/commands/translate/providers/ai/utils/index.spec.ts
@@ -1,0 +1,66 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {LLMAuthError, LLMRateLimitError, backoff} from './index';
+
+describe('translate ai utils', () => {
+    describe('backoff', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('should return the result on success', async () => {
+            const action = vi.fn().mockResolvedValue('ok');
+
+            await expect(backoff(action, 3)).resolves.toBe('ok');
+            expect(action).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not retry non-retryable errors', async () => {
+            const error = new LLMAuthError('denied');
+            const action = vi.fn().mockRejectedValue(error);
+
+            await expect(backoff(action, 3)).rejects.toBe(error);
+            expect(action).toHaveBeenCalledTimes(1);
+        });
+
+        it('should throw the original error when retries are disabled', async () => {
+            const error = new LLMRateLimitError('slow down');
+            const action = vi.fn().mockRejectedValue(error);
+
+            await expect(backoff(action, 0)).rejects.toBe(error);
+            expect(action).toHaveBeenCalledTimes(1);
+        });
+
+        it('should retry retryable errors up to the limit', async () => {
+            const error = new LLMRateLimitError('slow down');
+            const action = vi.fn().mockRejectedValue(error);
+
+            const promise = backoff(action, 2);
+            const failure = expect(promise).rejects.toBe(error);
+
+            await vi.runAllTimersAsync();
+            await failure;
+
+            expect(action).toHaveBeenCalledTimes(3);
+        });
+
+        it('should resolve when a retry succeeds', async () => {
+            const action = vi
+                .fn()
+                .mockRejectedValueOnce(new LLMRateLimitError('slow down'))
+                .mockResolvedValue('ok');
+
+            const promise = backoff(action, 2);
+            const success = expect(promise).resolves.toBe('ok');
+
+            await vi.runAllTimersAsync();
+            await success;
+
+            expect(action).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/src/commands/translate/providers/ai/utils/index.spec.ts
+++ b/src/commands/translate/providers/ai/utils/index.spec.ts
@@ -1,8 +1,22 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
-import {LLMAuthError, LLMRateLimitError, backoff} from './index';
+import {LLMAuthError, LLMRateLimitError, backoff, estimateTokens} from './index';
 
 describe('translate ai utils', () => {
+    describe('estimateTokens', () => {
+        it('should estimate latin text at ~4 chars per token', () => {
+            expect(estimateTokens('a'.repeat(40))).toBe(10);
+        });
+
+        it('should estimate non-latin text at ~2 chars per token', () => {
+            expect(estimateTokens('ы'.repeat(40))).toBe(20);
+        });
+
+        it('should combine both estimates for mixed text', () => {
+            expect(estimateTokens('a'.repeat(4) + 'ы'.repeat(4))).toBe(3);
+        });
+    });
+
     describe('backoff', () => {
         beforeEach(() => {
             vi.useFakeTimers();
@@ -58,6 +72,24 @@ describe('translate ai utils', () => {
             const success = expect(promise).resolves.toBe('ok');
 
             await vi.runAllTimersAsync();
+            await success;
+
+            expect(action).toHaveBeenCalledTimes(2);
+        });
+
+        it('should honor server-provided retry-after', async () => {
+            const action = vi
+                .fn()
+                .mockRejectedValueOnce(new LLMRateLimitError('slow down', 7))
+                .mockResolvedValue('ok');
+
+            const promise = backoff(action, 1);
+            const success = expect(promise).resolves.toBe('ok');
+
+            await vi.advanceTimersByTimeAsync(6999);
+            expect(action).toHaveBeenCalledTimes(1);
+
+            await vi.advanceTimersByTimeAsync(1);
             await success;
 
             expect(action).toHaveBeenCalledTimes(2);

--- a/src/commands/translate/providers/ai/utils/index.ts
+++ b/src/commands/translate/providers/ai/utils/index.ts
@@ -1,0 +1,63 @@
+export {LLMRequestError, LLMAuthError, LLMRateLimitError, LLMResponseError} from './errors';
+
+export class Defer<T = string> {
+    resolve!: (text: T) => void;
+
+    reject!: (error: unknown) => void;
+
+    promise: Promise<T>;
+
+    constructor() {
+        this.promise = new Promise((resolve, reject) => {
+            this.resolve = resolve;
+            this.reject = reject;
+        });
+    }
+}
+
+export function bytes(texts: string[]) {
+    return texts.reduce((sum, text) => sum + text.length, 0);
+}
+
+// Rough heuristic: ~4 chars per token. Good enough for budgeting and dry-run.
+export function estimateTokens(text: string) {
+    return Math.ceil(text.length / 4);
+}
+
+export function escapeRegExp(value: string) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export async function wait(interval: number) {
+    return new Promise<void>((resolve) => setTimeout(resolve, interval));
+}
+
+export async function backoff<T>(action: () => Promise<T>, retries: number): Promise<T> {
+    let attempt = 0;
+    let lastError: unknown;
+
+    while (attempt < retries) {
+        try {
+            return await action();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+            lastError = error;
+            if (!canRetry(error) || attempt === retries - 1) {
+                throw error;
+            }
+            await wait(Math.pow(2, attempt) * 1000);
+            attempt++;
+        }
+    }
+
+    throw lastError;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function canRetry(error: any) {
+    if (error?.retryable === true) {
+        return true;
+    }
+    const status = error?.status;
+    return status === 429 || status === 500 || status === 502 || status === 503 || status === 504;
+}

--- a/src/commands/translate/providers/ai/utils/index.ts
+++ b/src/commands/translate/providers/ai/utils/index.ts
@@ -1,4 +1,10 @@
-export {LLMRequestError, LLMAuthError, LLMRateLimitError, LLMResponseError} from './errors';
+export {
+    LLMRequestError,
+    LLMAuthError,
+    LLMRateLimitError,
+    LLMResponseError,
+    throwLLMError,
+} from './errors';
 
 export class Defer<T = string> {
     resolve!: (text: T) => void;
@@ -33,24 +39,19 @@ export async function wait(interval: number) {
 }
 
 export async function backoff<T>(action: () => Promise<T>, retries: number): Promise<T> {
-    let attempt = 0;
-    let lastError: unknown;
+    const attempts = Math.max(0, retries) + 1;
 
-    while (attempt < retries) {
+    for (let attempt = 0; ; attempt++) {
         try {
             return await action();
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
-            lastError = error;
-            if (!canRetry(error) || attempt === retries - 1) {
+            if (!canRetry(error) || attempt >= attempts - 1) {
                 throw error;
             }
             await wait(Math.pow(2, attempt) * 1000);
-            attempt++;
         }
     }
-
-    throw lastError;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/commands/translate/providers/ai/utils/index.ts
+++ b/src/commands/translate/providers/ai/utils/index.ts
@@ -1,3 +1,5 @@
+import {randomInt} from 'node:crypto';
+
 export {
     LLMRequestError,
     LLMAuthError,
@@ -67,7 +69,7 @@ function retryInterval(error: any, attempt: number): number {
         return error.retryAfter * 1000;
     }
 
-    return Math.pow(2, attempt) * 1000 * (1 + Math.random());
+    return Math.pow(2, attempt) * 1000 * (1 + randomInt(0, 1000) / 1000);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/commands/translate/providers/ai/utils/index.ts
+++ b/src/commands/translate/providers/ai/utils/index.ts
@@ -32,7 +32,7 @@ export function bytes(texts: string[]) {
 export function estimateTokens(text: string) {
     let ascii = 0;
     for (let i = 0; i < text.length; i++) {
-        if (text.charCodeAt(i) < 128) {
+        if ((text.codePointAt(i) ?? 0) < 128) {
             ascii++;
         }
     }

--- a/src/commands/translate/providers/ai/utils/index.ts
+++ b/src/commands/translate/providers/ai/utils/index.ts
@@ -25,13 +25,18 @@ export function bytes(texts: string[]) {
     return texts.reduce((sum, text) => sum + text.length, 0);
 }
 
-// Rough heuristic: ~4 chars per token. Good enough for budgeting and dry-run.
+// Rough heuristic for budgeting and dry-run: ~4 chars per token for
+// latin text, ~2 for the rest (Cyrillic and CJK tokenize much denser).
 export function estimateTokens(text: string) {
-    return Math.ceil(text.length / 4);
-}
+    let ascii = 0;
+    for (let i = 0; i < text.length; i++) {
+        if (text.charCodeAt(i) < 128) {
+            ascii++;
+        }
+    }
+    const other = text.length - ascii;
 
-export function escapeRegExp(value: string) {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return Math.ceil(ascii / 4 + other / 2);
 }
 
 export async function wait(interval: number) {
@@ -49,9 +54,20 @@ export async function backoff<T>(action: () => Promise<T>, retries: number): Pro
             if (!canRetry(error) || attempt >= attempts - 1) {
                 throw error;
             }
-            await wait(Math.pow(2, attempt) * 1000);
+            await wait(retryInterval(error, attempt));
         }
     }
+}
+
+// Respects the server-provided Retry-After when available, otherwise
+// exponential backoff with jitter to avoid synchronized retries.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function retryInterval(error: any, attempt: number): number {
+    if (error?.retryAfter > 0) {
+        return error.retryAfter * 1000;
+    }
+
+    return Math.pow(2, attempt) * 1000 * (1 + Math.random());
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/commands/translate/providers/yandex/index.ts
+++ b/src/commands/translate/providers/yandex/index.ts
@@ -81,6 +81,8 @@ export class Extension {
                     ok(config.auth, 'Required param auth is not configured');
                     ok(config.folder, 'Required param folder is not configured');
 
+                    config.timeout = (defined('timeout', args, config) as number) ?? 5000;
+
                     let glossary: AbsolutePath | undefined;
                     if (own<string, 'glossary'>(args, 'glossary')) {
                         glossary = join(args.input, args.glossary);


### PR DESCRIPTION
## Summary

Adds a new translation backend that runs documentation through an LLM. Sits next to the existing Yandex Cloud Translate provider and plugs into the same `Provider.for(name)` hook in `commands/translate/index.ts`, reusing the `extract -> translate(units) -> compose` pipeline - XLIFF skeleton, schemas, `vars`/`liquid`, glossary, `--filter` and `--dry-run` all keep working unchanged.

Four sub-providers are registered under `--provider`:

| Provider     | Default endpoint                                    |
|--------------|-----------------------------------------------------|
| `yandexgpt`  | `https://llm.api.cloud.yandex.net`                  |
| `openai`     | `https://api.openai.com/v1`                         |
| `openrouter` | `https://openrouter.ai/api/v1` (OpenAI-compatible)  |
| `anthropic`  | `https://api.anthropic.com/v1`                      |

### Options

Shared (all four providers):
- `--auth <token-or-path>` - raw token or path to a file. Env fallback (`YANDEX_API_KEY`/`YC_IAM_TOKEN`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`).
- `--model <name>` - short name or fully qualified URI (yandexgpt accepts both).
- `--api-base <url>` - base URL override for self-hosted and internal installations. The provider request path is appended automatically (`/chat/completions`, `/messages`, `/foundationModels/v1/completion`). Env fallback: `OPENAI_BASE_URL`, `OPENROUTER_BASE_URL`, `ANTHROPIC_BASE_URL`.
- `--api-header "Name: value"` - extra HTTP headers, repeatable (or an `apiHeaders` object in config). For internal gateways with custom auth schemes.
- `--system-prompt <value>` / `--user-prompt <value>` - string or path to a file. Placeholders: `{{source}}`, `{{target}}`, `{{glossary}}`, `{{separator}}`, `{{fragments}}`, `{{text}}`.
- `--prompt-mode append|replace` - `append` (default) appends the user system prompt to the built-in default; `replace` fully replaces it.
- `--glossary <path>` - same YAML format as the existing yandex provider.
- `--temperature`, `--max-output-tokens`, `--max-batch-tokens`, `--max-concurrency`, `--retry`, `--timeout` (defaults to 60s for LLM providers).

All options can also be set in the yfm config (except `auth`). CLI args take priority over config values.

Yandex-only: `--folder <id>` (required when `--model` is a short name).

### Reliability

- Translation units are batched by token budget; one LLM call per batch with a unique delimiter between fragments; repeated units are deduped through a cache.
- On fragment-count mismatch in the response the batch is automatically retried one-by-one before failing the file.
- Truncated responses (`stop_reason=max_tokens`, `finish_reason=length`, `ALTERNATIVE_STATUS_TRUNCATED_FINAL`) are detected and reported instead of producing broken output.
- Oversized units are skipped with a warning and keep the source text, mirroring the yandex provider.
- Exponential backoff with jitter on 429/5xx honoring `Retry-After`; auth and content-filter errors are non-retryable.
- `--dry-run` estimates input/output tokens without calling the LLM.
- Auth tokens are never read from the public yfm config (mirrors yandex provider behavior).

### Examples

```bash
docs translate --provider yandexgpt \
  --auth $YANDEX_API_KEY \
  --folder b1g... \
  --model yandexgpt-lite \
  --source ru --target en \
  --system-prompt ./prompts/system.md
```

Self-hosted or internal installation:

```bash
docs translate --provider openai \
  --api-base https://llm.internal.example/v1 \
  --api-header "X-Org: docs" \
  --auth $LLM_GATEWAY_TOKEN \
  --model my-model \
  --source ru --target en
```
