### PR TITLE
fix(template): preserve whitespace in body interpolation in Template.dump

### DIFF
--- a/src/core/template/template.spec.ts
+++ b/src/core/template/template.spec.ts
@@ -91,4 +91,68 @@ describe('Template', () => {
             expect(html).not.toContain('Content-Security-Policy');
         });
     });
+
+    describe('dump body interpolation', () => {
+        it('should render default root container when body is empty', () => {
+            const template = new Template('index.html' as RelativePath, 'en');
+
+            const html = template.dump();
+
+            expect(html).toContain('<div id="root"></div>');
+        });
+
+        // Regression: https://github.com/diplodoc-platform/cli/issues/1893
+        // ts-dedent must not re-indent whitespace-significant body content.
+        it('should preserve whitespace in multi-line <pre><code> body', () => {
+            const code = [
+                '<pre><code class="hljs bash"># 1. comment',
+                './init.sh --dump-postgres',
+                '',
+                './init.sh --pg-sql',
+                '</code></pre>',
+            ].join('\n');
+            const template = new Template('index.html' as RelativePath, 'en');
+            template.addBody(code);
+
+            const html = template.dump();
+
+            // body lines must keep their original (zero) indentation
+            expect(html).toContain(code);
+            // no extra leading indentation injected on subsequent lines
+            expect(html).not.toMatch(/\n {2,}\.\/init\.sh --dump-postgres/);
+        });
+
+        it('should not re-indent lines of a multi-line body', () => {
+            const body = 'first\nsecond\nthird';
+            const template = new Template('index.html' as RelativePath, 'en');
+            template.addBody(body);
+
+            const html = template.dump();
+
+            expect(html).toContain('first\nsecond\nthird');
+        });
+
+        // The replacement must use a replacer function so the special patterns
+        // ($$, $&, $`, $', $n) of String.prototype.replace are NOT interpreted.
+        it('should insert body verbatim when it contains $-replacement patterns', () => {
+            const body = "<p>$$ and $& and $` and $' and $1 and $<name></p>";
+            const template = new Template('index.html' as RelativePath, 'en');
+            template.addBody(body);
+
+            const html = template.dump();
+
+            expect(html).toContain(body);
+            expect(html).toContain('$$ and $& and');
+        });
+
+        it('should concatenate multiple body fragments with newlines', () => {
+            const template = new Template('index.html' as RelativePath, 'en');
+            template.addBody('<div>one</div>');
+            template.addBody('<div>two</div>');
+
+            const html = template.dump();
+
+            expect(html).toContain('<div>one</div>\n<div>two</div>');
+        });
+    });
 });

--- a/src/core/template/template.ts
+++ b/src/core/template/template.ts
@@ -339,6 +339,11 @@ export class Template {
         const base = getDepthPath(getDepth(this.path) - 1);
         const faviconType = getFaviconType(faviconSrc);
 
+        // ts-dedent re-indents every line of a multi-line interpolation,
+        // which corrupts whitespace-significant content (e.g. <pre><code> blocks) inside body
+        // insert body via a placeholder so its newlines stay untouched
+        const BODY = '\x00BODY\x00';
+
         return dedent`
             <!DOCTYPE html>
             <html lang="${lang}" dir="${this.isRTL ? 'rtl' : 'ltr'}">
@@ -357,13 +362,13 @@ export class Template {
                     ${leading(styles).map(style(this.csp)).join('\n')}
                 </head>
                 <body class="${bodyClass.join(' ')}">
-                    ${body.join('\n') || `<div id="root"></div>`}
+                    ${BODY}
                     ${state(scripts).map(script(this.csp)).join('\n')}
                     ${trailing(scripts).map(script(this.csp)).join('\n')}
                     ${trailing(styles).map(style(this.csp)).join('\n')}
                 </body>
             </html>
-        `;
+        `.replace(BODY, () => body.join('\n') || `<div id="root"></div>`);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #1893.

`Template.dump()` (introduced in `5.0.0-rc-8`) builds the final page using a `ts-dedent` template literal. `ts-dedent` strips the common leading indent from the literal but **also re-indents every line of a multi-line interpolation** to the column of the `${...}` placeholder.

`body.join('\n')` is interpolated 8 spaces deep inside `<body>`, so every line **after the first** of the SSR-rendered body markup gets 8 extra spaces prepended. For most tags this is invisible, but inside whitespace-significant content like `<pre><code>` blocks the extra indent shows up verbatim in the rendered page:

```html
<!-- before -->
<pre><code class="hljs bash">./first-line.sh
        ./second-line.sh        <!-- 8 extra spaces -->
        ./third-line.sh         <!-- 8 extra spaces -->
</code></pre>
```

## Fix

Insert `body.join('\n')` via a placeholder (`\x00BODY\x00`) and substitute it with `.replace()` **after** `dedent` has finished processing, so the body's newlines stay untouched. Body is the only whitespace-significant interpolation in the template, so other interpolations don't need protection.

## Reproduction

Standalone `ts-dedent` repro (10 lines), regression range `5.0.0-rc-4` (clean) → `5.0.0-rc-8` (broken), and full evidence are in the linked issue (#1893).

## Verification

Built `lib/template` from the patched source, dropped it into `node_modules/@diplodoc/cli/lib/template/` of a real docs project, and ran a full `npx @diplodoc/cli` build. Generated `<pre><code>` blocks now contain content with 0 leading spaces — matching the `4.x` behaviour.

Closes #1893