### PR TITLE
chore(e2e): make bundles test resilient to chunk changes

### DIFF
--- a/tests/e2e/__snapshots__/bundles.spec.ts.snap
+++ b/tests/e2e/__snapshots__/bundles.spec.ts.snap
@@ -3,28 +3,6 @@
 exports[`Check bundles > bundles list is correct > filelist 1`] = `
 "[
   ".yfm",
-  "_bundle/app-css",
-  "_bundle/app-js",
-  "_bundle/app-rtl-css",
-  "_bundle/chunk-js",
-  "_bundle/latex-extension.css",
-  "_bundle/latex-extension.js",
-  "_bundle/mermaid-extension.js",
-  "_bundle/page-constructor-extension.css",
-  "_bundle/page-constructor-extension.js",
-  "_bundle/react-js",
-  "_bundle/search-css",
-  "_bundle/search-js",
-  "_bundle/search-rtl-css",
-  "_bundle/vendor-css",
-  "_bundle/vendor-js",
-  "_bundle/vendor-rtl-css",
-  "_search/api.js",
-  "_search/ru/hash-index.js",
-  "_search/ru/hash-registry.js",
-  "_search/ru/hash-resources.js",
-  "_search/ru/index.html",
-  "_search/ru/language.js",
   "index.html",
   "page1.html",
   "page2.html",
@@ -57,16 +35,11 @@ exports[`Check bundles > bundles list is correct 2`] = `
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <base href="./" />
         <title>Header | Skip html extension</title>
-        
-        
         <meta name="generator" content="Diplodoc Platform vDIPLODOC-VERSION">
         <meta name="availableLangs" content="en,ru">
         <meta http-equiv="Content-Security-Policy" content="worker-src 'self';">
         <style type="text/css">html, body {min-height:100vh; height:100vh;}</style>
         <link rel="icon" type="image/x-icon" href="https://storage.yandexcloud.net/diplodoc-www-assets/favicon/favicon.ico">
-        
-        <link type="text/css" rel="stylesheet" href="_bundle/app-css"/>
-        <link type="text/css" rel="stylesheet" href="_bundle/vendor-css"/>
     </head>
     <body class="g-root g-root_theme_light">
         <div id="root"></div>
@@ -81,11 +54,6 @@ exports[`Check bundles > bundles list is correct 2`] = `
             window.STATIC_CONTENT = false;
         </script>
         <script type="application/javascript" defer src="toc.js"></script>
-        <script type="application/javascript" defer src="_search/ru/hash-resources.js"></script>
-        <script type="application/javascript" defer src="_bundle/app-js"></script>
-        <script type="application/javascript" defer src="_bundle/react-js"></script>
-        <script type="application/javascript" defer src="_bundle/vendor-js"></script>
-        
     </body>
 </html>"
 `;
@@ -98,15 +66,10 @@ exports[`Check bundles > bundles list is correct 3`] = `
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <base href="./" />
         <title>Page 1 | Skip html extension</title>
-        
-        
         <meta name="generator" content="Diplodoc Platform vDIPLODOC-VERSION">
         <meta http-equiv="Content-Security-Policy" content="worker-src 'self';">
         <style type="text/css">html, body {min-height:100vh; height:100vh;}</style>
         <link rel="icon" type="image/x-icon" href="https://storage.yandexcloud.net/diplodoc-www-assets/favicon/favicon.ico">
-        
-        <link type="text/css" rel="stylesheet" href="_bundle/app-css"/>
-        <link type="text/css" rel="stylesheet" href="_bundle/vendor-css"/>
     </head>
     <body class="g-root g-root_theme_light">
         <div id="root"></div>
@@ -121,11 +84,6 @@ exports[`Check bundles > bundles list is correct 3`] = `
             window.STATIC_CONTENT = false;
         </script>
         <script type="application/javascript" defer src="toc.js"></script>
-        <script type="application/javascript" defer src="_search/ru/hash-resources.js"></script>
-        <script type="application/javascript" defer src="_bundle/app-js"></script>
-        <script type="application/javascript" defer src="_bundle/react-js"></script>
-        <script type="application/javascript" defer src="_bundle/vendor-js"></script>
-        
     </body>
 </html>"
 `;
@@ -138,15 +96,10 @@ exports[`Check bundles > bundles list is correct 4`] = `
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <base href="./" />
         <title>Page 2 | Skip html extension</title>
-        
-        
         <meta name="generator" content="Diplodoc Platform vDIPLODOC-VERSION">
         <meta http-equiv="Content-Security-Policy" content="worker-src 'self';">
         <style type="text/css">html, body {min-height:100vh; height:100vh;}</style>
         <link rel="icon" type="image/x-icon" href="https://storage.yandexcloud.net/diplodoc-www-assets/favicon/favicon.ico">
-        
-        <link type="text/css" rel="stylesheet" href="_bundle/app-css"/>
-        <link type="text/css" rel="stylesheet" href="_bundle/vendor-css"/>
     </head>
     <body class="g-root g-root_theme_light">
         <div id="root"></div>
@@ -161,11 +114,6 @@ exports[`Check bundles > bundles list is correct 4`] = `
             window.STATIC_CONTENT = false;
         </script>
         <script type="application/javascript" defer src="toc.js"></script>
-        <script type="application/javascript" defer src="_search/ru/hash-resources.js"></script>
-        <script type="application/javascript" defer src="_bundle/app-js"></script>
-        <script type="application/javascript" defer src="_bundle/react-js"></script>
-        <script type="application/javascript" defer src="_bundle/vendor-js"></script>
-        
     </body>
 </html>"
 `;

--- a/tests/e2e/bundles.spec.ts
+++ b/tests/e2e/bundles.spec.ts
@@ -1,6 +1,18 @@
-import {describe, it} from 'vitest';
+import {readFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+import {glob} from 'glob';
+import {describe, expect, it} from 'vitest';
+import assets from '@diplodoc/cli/manifest';
 
 import {TestAdapter, compareDirectories, getTestPaths} from '../fixtures';
+
+const EXPECTED_EXTENSIONS = [
+    'latex-extension.css',
+    'latex-extension.js',
+    'mermaid-extension.js',
+    'page-constructor-extension.css',
+    'page-constructor-extension.js',
+];
 
 describe('Check bundles', () => {
     it('bundles list is correct', async () => {
@@ -11,6 +23,52 @@ describe('Check bundles', () => {
             md2html: true,
             args: '-j2',
         });
-        await compareDirectories(outputPath, false, true);
+
+        const allFiles = await glob('**/*', {
+            cwd: outputPath,
+            dot: true,
+            follow: true,
+            nodir: true,
+            posix: true,
+        });
+
+        const bundleFiles = allFiles.filter((f) => f.startsWith('_bundle/'));
+        const bundleBasenames = new Set(bundleFiles.map((f) => f.slice('_bundle/'.length)));
+
+        // Every manifest entry must be present in the output
+        for (const entry of Object.values(assets)) {
+            for (const files of Object.values(entry as Record<string, string[]>)) {
+                for (const file of files) {
+                    expect(bundleBasenames, `missing manifest entry: ${file}`).toContain(file);
+                }
+            }
+        }
+
+        // Extension bundles must be present
+        for (const ext of EXPECTED_EXTENSIONS) {
+            expect(bundleBasenames, `missing extension bundle: ${ext}`).toContain(ext);
+        }
+
+        // HTML pages should only reference bundles and search files that exist in output
+        const outputFiles = new Set(allFiles);
+        const htmlFiles = allFiles.filter((f) => f.endsWith('.html') && !f.startsWith('_search/'));
+        for (const htmlFile of htmlFiles) {
+            const content = readFileSync(resolve(outputPath, htmlFile), 'utf8');
+            const refs = [...content.matchAll(/(?:src|href)="(_(?:bundle|search)\/[^"]+)"/g)].map(
+                (m) => m[1],
+            );
+            for (const ref of refs) {
+                expect(outputFiles, `${htmlFile} references missing file: ${ref}`).toContain(ref);
+            }
+        }
+
+        // Search index must be generated (local search is configured in this mock)
+        const searchFiles = allFiles.filter((f) => f.startsWith('_search/'));
+        expect(searchFiles.some((f) => f.endsWith('/api.js'))).toBe(true);
+        expect(searchFiles.some((f) => f.endsWith('/index.html'))).toBe(true);
+        expect(searchFiles.some((f) => f.endsWith('/language.js'))).toBe(true);
+
+        // Verify non-bundle content via standard snapshot comparison (strips system links)
+        await compareDirectories(outputPath);
     });
 });


### PR DESCRIPTION
## Summary
- Replace fragile exact-filelist snapshot in `bundles.spec.ts` with explicit assertions that don't break on `@diplodoc/client` updates
- Verify all manifest entries are present in `_bundle/` output
- Verify extension bundles (latex, mermaid, page-constructor) are present
- Assert HTML `<script>`/`<link>` references point to existing bundle and search files
- Verify search index is generated (`api.js`, `index.html`, `language.js`)
- Use `compareDirectories` defaults (`stripSystemLinks`) for content snapshots — HTML snapshots no longer contain bundle filenames

No snapshots depend on webpack chunk names or counts, so the test is fully stable across dependency updates.