### PR TITLE
feat(build): enable build-stats and build-content by default for md2md

### DIFF
--- a/src/commands/build/features/build-content-map/config.ts
+++ b/src/commands/build/features/build-content-map/config.ts
@@ -10,6 +10,9 @@ const buildContent = option({
         per-file sha256 hashes and page→asset dependencies. Used by downstream tools
         to compute the set of pages changed between any two build revisions
         (search reindexing, change notifications).
+
+        Enabled by default for ${bold('--output-format=md')} builds; disabled
+        otherwise. Use ${bold('--no-build-content')} to opt out.
     `,
 });
 

--- a/src/commands/build/features/build-content-map/index.spec.ts
+++ b/src/commands/build/features/build-content-map/index.spec.ts
@@ -21,34 +21,64 @@ import {
 
 describe('BuildContentMap', () => {
     describe('config wiring', () => {
-        it('exposes --build-content option and normalizes config flag', async () => {
+        const tapByName = (taps: FullTap[], name: string) => {
+            const tap = taps.find((t) => t.name === name);
+            if (!tap) throw new Error(`tap ${name} not registered`);
+            return tap.fn;
+        };
+
+        const setupConfigTap = () => {
             const build = new Build();
             new BuildContentMap().apply(build);
-
-            const tapByName = (taps: FullTap[], name: string) => {
-                const tap = taps.find((t) => t.name === name);
-                if (!tap) throw new Error(`tap ${name} not registered`);
-                return tap.fn;
+            return {
+                build,
+                configTap: tapByName(getBaseHooks(build).Config.taps, 'BuildContentMap'),
             };
+        };
 
+        it('exposes --build-content option', () => {
+            const {build} = setupConfigTap();
             const commandTap = tapByName(getBaseHooks(build).Command.taps, 'BuildContentMap');
-            const configTap = tapByName(getBaseHooks(build).Config.taps, 'BuildContentMap');
 
-            // Command tap should add an option without throwing.
             const seenOptions: unknown[] = [];
             const fakeCommand = {addOption: (o: unknown) => seenOptions.push(o)};
             commandTap(fakeCommand);
             expect(seenOptions).toHaveLength(1);
+        });
 
-            // Config tap should set buildContent=true when arg=true.
-            const config = {} as BuildConfig;
+        it('arg=true forces buildContent=true (html default would be off)', async () => {
+            const {configTap} = setupConfigTap();
+            const config = {outputFormat: 'html'} as BuildConfig;
             const result = await configTap(config, {buildContent: true});
             expect(result.buildContent).toBe(true);
+        });
 
-            // And false when nothing is set.
-            const config2 = {} as BuildConfig;
-            const result2 = await configTap(config2, {});
-            expect(result2.buildContent).toBe(false);
+        it('defaults to false for html when nothing is set', async () => {
+            const {configTap} = setupConfigTap();
+            const config = {outputFormat: 'html'} as BuildConfig;
+            const result = await configTap(config, {});
+            expect(result.buildContent).toBe(false);
+        });
+
+        it('defaults to true for md when nothing is set', async () => {
+            const {configTap} = setupConfigTap();
+            const config = {outputFormat: 'md'} as BuildConfig;
+            const result = await configTap(config, {});
+            expect(result.buildContent).toBe(true);
+        });
+
+        it('arg=false overrides the md default (opt-out via --no-build-content)', async () => {
+            const {configTap} = setupConfigTap();
+            const config = {outputFormat: 'md'} as BuildConfig;
+            const result = await configTap(config, {buildContent: false});
+            expect(result.buildContent).toBe(false);
+        });
+
+        it('config=false overrides the md default (opt-out via yfm config)', async () => {
+            const {configTap} = setupConfigTap();
+            const config = {outputFormat: 'md', buildContent: false} as BuildConfig;
+            const result = await configTap(config, {});
+            expect(result.buildContent).toBe(false);
         });
     });
 

--- a/src/commands/build/features/build-content-map/index.ts
+++ b/src/commands/build/features/build-content-map/index.ts
@@ -9,6 +9,7 @@ import pmap from 'p-map';
 
 import {getHooks as getBaseHooks} from '~/core/program';
 import {valuable} from '~/core/config';
+import {OutputFormat} from '~/commands/build/config';
 
 import {options} from './config';
 
@@ -321,7 +322,12 @@ export class BuildContentMap {
         });
 
         getBaseHooks(program).Config.tapPromise('BuildContentMap', async (config, args) => {
-            let buildContent = false;
+            // Default to on for md2md builds: the content map is consumed by
+            // post-build tooling (search reindex, change notifications) that
+            // diffs the md output uploaded from this format. For html builds
+            // it stays off — there's no comparable consumer there yet. Users
+            // can flip either side via `--no-build-content` / `buildContent: false`.
+            let buildContent = config.outputFormat === OutputFormat.md;
 
             if (valuable(config.buildContent)) {
                 buildContent = Boolean(config.buildContent);

--- a/src/commands/build/features/build-stats/config.ts
+++ b/src/commands/build/features/build-stats/config.ts
@@ -9,6 +9,9 @@ const buildStats = option({
         Output a build stats file (${bold('yfm-build-stats.json')}) with timing,
         environment info and counters. Intended for diagnostics, CI dashboards
         and regression detection.
+
+        Enabled by default for ${bold('--output-format=md')} builds; disabled
+        otherwise. Use ${bold('--no-build-stats')} to opt out.
     `,
 });
 

--- a/src/commands/build/features/build-stats/index.spec.ts
+++ b/src/commands/build/features/build-stats/index.spec.ts
@@ -15,6 +15,55 @@ import {Build} from '../..';
 import {BuildStats, collectFeatures} from './index';
 
 describe('BuildStats', () => {
+    describe('config wiring', () => {
+        const tapByName = (taps: FullTap[], name: string) => {
+            const tap = taps.find((t) => t.name === name);
+            if (!tap) throw new Error(`tap ${name} not registered`);
+            return tap.fn;
+        };
+
+        const setupConfigTap = () => {
+            const build = new Build();
+            new BuildStats().apply(build);
+            return tapByName(getBaseHooks(build).Config.taps, 'BuildStats');
+        };
+
+        it('defaults to false for html when nothing is set', async () => {
+            const configTap = setupConfigTap();
+            const config = {outputFormat: 'html'} as BuildConfig;
+            const result = await configTap(config, {});
+            expect(result.buildStats).toBe(false);
+        });
+
+        it('defaults to true for md when nothing is set', async () => {
+            const configTap = setupConfigTap();
+            const config = {outputFormat: 'md'} as BuildConfig;
+            const result = await configTap(config, {});
+            expect(result.buildStats).toBe(true);
+        });
+
+        it('arg=true forces buildStats=true (html default would be off)', async () => {
+            const configTap = setupConfigTap();
+            const config = {outputFormat: 'html'} as BuildConfig;
+            const result = await configTap(config, {buildStats: true});
+            expect(result.buildStats).toBe(true);
+        });
+
+        it('arg=false overrides the md default (opt-out via --no-build-stats)', async () => {
+            const configTap = setupConfigTap();
+            const config = {outputFormat: 'md'} as BuildConfig;
+            const result = await configTap(config, {buildStats: false});
+            expect(result.buildStats).toBe(false);
+        });
+
+        it('config=false overrides the md default (opt-out via yfm config)', async () => {
+            const configTap = setupConfigTap();
+            const config = {outputFormat: 'md', buildStats: false} as BuildConfig;
+            const result = await configTap(config, {});
+            expect(result.buildStats).toBe(false);
+        });
+    });
+
     describe('collectFeatures', () => {
         it('returns config keys with literal `true`, sorted, ignoring truthy non-`true` values', () => {
             const features = collectFeatures({

--- a/src/commands/build/features/build-stats/index.ts
+++ b/src/commands/build/features/build-stats/index.ts
@@ -11,6 +11,7 @@ import {valuable} from '~/core/config';
 import {VERSION} from '~/constants';
 import {getHooks as getLoggerHooks, stats as loggerStats} from '~/core/logger';
 import {langFromPath} from '~/core/utils';
+import {OutputFormat} from '~/commands/build/config';
 
 import {options} from './config';
 
@@ -134,7 +135,13 @@ export class BuildStats {
         });
 
         getBaseHooks(program).Config.tapPromise('BuildStats', async (config, args) => {
-            let buildStats = false;
+            // Default to on for md2md builds: CI pipelines for md→md
+            // benefit from the artifact (regression tracking, asset accounting),
+            // and the read overhead is dominated by the build itself in this
+            // mode. For html builds it stays off — local dev shouldn't pay the
+            // extra fs walk by default. Users can flip either side via
+            // `--no-build-stats` / `buildStats: false`.
+            let buildStats = config.outputFormat === OutputFormat.md;
 
             if (valuable(config.buildStats)) {
                 buildStats = Boolean(config.buildStats);

--- a/tests/fixtures/utils/file.ts
+++ b/tests/fixtures/utils/file.ts
@@ -12,6 +12,15 @@ import {bundleless, hashless, platformless} from './test';
 
 const SYSTEM_DIRS = ['_bundle/', '_search/'];
 
+// CLI-emitted build artifacts that aren't part of user content. Build-stats
+// and build-content default to on for md2md, so every md2md fixture would
+// otherwise need to list these in its snapshot.
+const SYSTEM_ARTIFACTS = [
+    'yfm-build-manifest.json',
+    'yfm-build-stats.json',
+    'yfm-build-content.json',
+];
+
 export function getFileContent(filePath: string) {
     return platformless(bundleless(readFileSync(filePath, 'utf8')));
 }
@@ -78,7 +87,9 @@ export async function compareDirectories(
     if (checkBundle) {
         filesForSnapshot = filesFromOutput;
     } else {
-        filesForSnapshot = filesFromOutput.filter((file) => uselessFile(file, SYSTEM_DIRS));
+        filesForSnapshot = filesFromOutput.filter((file) =>
+            uselessFile(file, [...SYSTEM_DIRS, ...SYSTEM_ARTIFACTS]),
+        );
     }
 
     // Here we sort the order of the included files after all processing
@@ -93,7 +104,7 @@ export async function compareDirectories(
 
     if (!ignoreFileContent) {
         filesFromOutput
-            .filter((file) => uselessFile(file, ['_assets/', ...SYSTEM_DIRS]))
+            .filter((file) => uselessFile(file, ['_assets/', ...SYSTEM_DIRS, ...SYSTEM_ARTIFACTS]))
             .forEach((filePath) => {
                 let content = getFileContent(resolve(outputPath, filePath));
 


### PR DESCRIPTION
## Summary

For \`--output-format=md\` builds, both \`--build-stats\` and \`--build-content\` now default to \`true\` so md2md CI pipelines emit \`yfm-build-stats.json\` and \`yfm-build-content.json\` without an explicit opt-in. For \`html\` builds the flags stay off by default — local dev doesn't pay for an extra fs walk by default, and the content map's main consumers (search reindex, change notifications) read from the md2md output anyway.

Per-feature `Config` hooks resolve the default at config-resolution time using `config.outputFormat`, so explicit `--no-build-stats` / `--no-build-content` and yfm-config `buildStats: false` / `buildContent: false` continue to win over the per-format default.

The flag descriptions in `yfm --help` are updated accordingly.

A docs PR is opened separately.