### PR TITLE
feat(build): generate llms.txt and llms-full.txt

### DIFF
--- a/src/commands/build/features/build-content-map/index.ts
+++ b/src/commands/build/features/build-content-map/index.ts
@@ -134,11 +134,20 @@ const ARTIFACT_FILENAMES = new Set([
 // `yfm-redirects-meta-file.json`).
 const META_ARTIFACT_RE = /^yfm-.+-meta.*\.json$/;
 
+// `llms.txt` / `llms-full.txt` are emitted per-toc (so they may live in nested
+// language/section dirs, not only at the output root). They are derived from
+// the entries' own content and change on every edit, so they must not pollute
+// `contentHashes` — match them by basename regardless of directory depth.
+const LLMS_ARTIFACT_RE = /(^|\/)llms(-full)?\.txt$/;
+
 export function isExcludedServiceFile(outputPath: NormalizedPath): boolean {
     if (outputPath.startsWith(TMP_INPUT_PREFIX)) {
         return true;
     }
     if (ARTIFACT_FILENAMES.has(outputPath)) {
+        return true;
+    }
+    if (LLMS_ARTIFACT_RE.test(outputPath)) {
         return true;
     }
     return META_ARTIFACT_RE.test(outputPath);

--- a/src/commands/build/features/llms/config.ts
+++ b/src/commands/build/features/llms/config.ts
@@ -1,0 +1,12 @@
+import {option} from '~/core/config';
+
+const llms = option({
+    flags: '--llms',
+    desc:
+        'Generate llms.txt (index) and llms-full.txt (full markdown) per toc for LLM consumption. ' +
+        'Works for both `md` and `html` output.',
+});
+
+export const options = {
+    llms,
+};

--- a/src/commands/build/features/llms/index.ts
+++ b/src/commands/build/features/llms/index.ts
@@ -1,0 +1,179 @@
+import type {Build, Run} from '~/commands/build';
+import type {Command} from '~/core/config';
+import type {EntryTocItem, Toc} from '~/core/toc';
+
+import {dirname, join} from 'node:path';
+
+import {getHooks as getBaseHooks} from '~/core/program';
+import {valuable} from '~/core/config';
+import {normalizePath, setExt} from '~/core/utils';
+import {OutputFormat} from '~/commands/build/config';
+
+import {MarkdownCollector, SELF_CONTAINED} from '../output-md/collect';
+
+import {options} from './config';
+
+export const LLMS_INDEX_FILENAME = 'llms.txt';
+export const LLMS_FULL_FILENAME = 'llms-full.txt';
+
+export type LlmsArgs = {
+    llms: boolean;
+};
+
+export type LlmsConfig = {
+    llms: boolean;
+};
+
+type LlmsEntry = {
+    // Href relative to the toc directory, as written in the toc — used for links.
+    href: NormalizedPath;
+    // Full normalized path from the input root — used to read meta / markdown.
+    path: NormalizedPath;
+    name: string;
+};
+
+/**
+ * Generates `llms.txt` (a compact index) and `llms-full.txt` (the whole
+ * documentation concatenated) per toc, following the https://llmstxt.org spec.
+ *
+ * Runs in `AfterAnyRun`, so it works for both `md` and `html` builds. By that
+ * point the toc is already resolved and filtered for the current build
+ * (vars/conditions, `removeHiddenTocItems`/`removeEmptyTocItems`), which keeps
+ * the artifacts consistent with the exact "version" produced by single-source
+ * publishing — hidden pages don't leak into the index and inactive `{% if %}`
+ * branches don't leak into the full text. Walking `run.toc.tocs` +
+ * `walkEntries` mirrors `SinglePage`.
+ *
+ * `llms-full.txt` is assembled with {@link MarkdownCollector} — the same engine
+ * `OutputMd` uses — so every include is merged into self-contained markdown
+ * regardless of the build's output format (no md/html fork).
+ *
+ * Index links point to the actual output files: original href in `md`, the
+ * rendered `.html` in `html`.
+ */
+export class Llms {
+    apply(program: Build) {
+        getBaseHooks(program).Command.tap('Llms', (command: Command) => {
+            command.addOption(options.llms);
+        });
+
+        getBaseHooks(program).Config.tap('Llms', (config, args) => {
+            let llms = false;
+
+            if (valuable(config.llms)) {
+                llms = Boolean(config.llms);
+            }
+
+            if (valuable(args.llms)) {
+                llms = Boolean(args.llms);
+            }
+
+            config.llms = llms;
+
+            return config;
+        });
+
+        getBaseHooks<Run>(program).AfterAnyRun.tapPromise('Llms', async (run) => {
+            if (!run.config.llms) {
+                return;
+            }
+
+            for (const toc of run.toc.tocs) {
+                try {
+                    await this.generate(run, toc);
+                } catch (error) {
+                    run.logger.error(`Unable to generate llms.txt for ${toc.path}: ${error}`);
+                }
+            }
+        });
+    }
+
+    private async generate(run: Run, toc: Toc) {
+        const tocDir = dirname(toc.path);
+        const entries: LlmsEntry[] = [];
+
+        await run.toc.walkEntries([toc as unknown as EntryTocItem], (item) => {
+            if (typeof item.href === 'string' && item.href) {
+                entries.push({
+                    href: item.href,
+                    path: normalizePath(join(tocDir, item.href)),
+                    name: typeof item.name === 'string' ? item.name : '',
+                });
+            }
+
+            return item;
+        });
+
+        if (!entries.length) {
+            return;
+        }
+
+        const title = toc.title || '';
+
+        const index = await this.renderIndex(run, title, entries);
+        const full = await this.renderFull(run, title, entries);
+
+        await run.write(join(run.output, tocDir, LLMS_INDEX_FILENAME), index, true);
+        await run.write(join(run.output, tocDir, LLMS_FULL_FILENAME), full, true);
+    }
+
+    private async renderIndex(run: Run, title: string, entries: LlmsEntry[]) {
+        const html = run.config.outputFormat === OutputFormat.html;
+        const lines: string[] = [];
+
+        if (title) {
+            lines.push(`# ${title}`, '');
+        }
+
+        for (const entry of entries) {
+            const meta = await run.meta.dump(entry.path);
+            const description = typeof meta.description === 'string' ? meta.description : '';
+            // Prefer the toc name; fall back to the page title (e.g. the root
+            // entry has no toc item name), then description, then the href.
+            const pageTitle = typeof meta.title === 'string' ? meta.title : '';
+            const name = entry.name || pageTitle || description || entry.href;
+            const suffix = description ? `: ${description}` : '';
+            // Link to the real output file: rendered .html for html builds,
+            // the original href (.md/.yaml) for md builds.
+            const href = html ? setExt(entry.href, 'html') : entry.href;
+
+            lines.push(`- [${name}](${href})${suffix}`);
+        }
+
+        return lines.join('\n') + '\n';
+    }
+
+    private async renderFull(run: Run, title: string, entries: LlmsEntry[]) {
+        const parts: string[] = [];
+
+        if (title) {
+            parts.push(`# ${title}`);
+        }
+
+        // Assemble fully self-contained markdown (all includes merged),
+        // independent of the build's output format — see MarkdownCollector.
+        const collector = new MarkdownCollector(run, SELF_CONTAINED);
+
+        for (const entry of entries) {
+            // Leading (yaml) pages have no markdown body to inline; they still
+            // appear in the index above.
+            if (!entry.path.endsWith('.md')) {
+                continue;
+            }
+
+            let body = '';
+            try {
+                body = (await collector.collect(entry.path)).trim();
+            } catch (error) {
+                run.logger.warn(`llms-full.txt: unable to assemble ${entry.path}: ${error}`);
+                continue;
+            }
+
+            if (body) {
+                parts.push(body);
+            }
+        }
+
+        return parts.join('\n\n') + '\n';
+    }
+}

--- a/src/commands/build/features/output-md/collect.ts
+++ b/src/commands/build/features/output-md/collect.ts
@@ -1,0 +1,177 @@
+import type {Run} from '~/commands/build';
+import type {EntryGraph, EntryGraphNode} from '~/core/markdown';
+import type {HashedGraphNode} from './utils';
+
+import {join} from 'node:path';
+
+import {all, get} from '~/core/utils';
+
+import {Scheduler, addMetaFrontmatter, rehashContent, signlink} from './utils';
+import {mergeSvg} from './plugins/merge-svg';
+import {mergeAutotitles} from './plugins/merge-autotitles';
+import {mergeIncludes} from './plugins/merge-includes';
+import {rehashIncludes} from './plugins/resolve-deps';
+
+export type CollectConfig = {
+    hashIncludes: boolean;
+    mergeIncludes: boolean;
+    mergeAutotitles: boolean;
+    mergeSvg: boolean;
+    disableMetaMaxLineWidth: boolean;
+    mergeIncludesSourceMaps: boolean;
+};
+
+/**
+ * Preset that fully inlines a page into self-contained markdown, independent of
+ * the active output format. Used by features that need resolved markdown even
+ * during an `html` build (e.g. `Llms`). Includes and autotitles are merged;
+ * svg inlining and content hashing are left off (svg xml / hashed links would
+ * just be noise for a plain markdown corpus), and include source-map comments
+ * are omitted.
+ */
+export const SELF_CONTAINED: CollectConfig = {
+    hashIncludes: false,
+    mergeIncludes: true,
+    mergeAutotitles: true,
+    mergeSvg: false,
+    disableMetaMaxLineWidth: false,
+    mergeIncludesSourceMaps: false,
+};
+
+/**
+ * Single source of truth for "how a page becomes self-contained markdown".
+ *
+ * Recursively walks the entry's dependency graph and merges includes /
+ * autotitles / inline svg via the shared step plugins. For the `OutputMd` case
+ * (when `mergeIncludes` is off) it also copies non-merged include files to the
+ * output, with metadata frontmatter — that branch is unreachable when merging.
+ *
+ * `OutputMd` drives it with the user's preprocess config; other features reuse
+ * it with {@link SELF_CONTAINED} to obtain fully-merged markdown regardless of
+ * the build's output format. Extracted verbatim from `OutputMd`'s dump closure
+ * so the two never drift.
+ *
+ * Memoization (`processed`/`titles`/`svgList`) is per-instance, so callers
+ * create one collector per logical batch (`OutputMd`: per entry vfile). The
+ * `copiedIncludes` set is shared run-wide to dedupe include file copies.
+ */
+export class MarkdownCollector {
+    // Untyped (like the original OutputMd closure): HashedGraphNode pulls in
+    // node's UrlWithStringQuery `search`/`hash` fields via IncludeInfo, which
+    // the root graph node doesn't carry. Keeping these loose matches the
+    // verbatim-extracted logic without fighting that quirk.
+    private readonly processed = new Map();
+    private readonly titles = new Map<string, string>();
+    private readonly svgList = new Map<string, string>();
+
+    private readonly run: Run;
+    private readonly config: Partial<CollectConfig>;
+    private readonly copiedIncludes: Set<string>;
+
+    constructor(run: Run, config: Partial<CollectConfig>, copiedIncludes: Set<string> = new Set()) {
+        this.run = run;
+        this.config = config;
+        this.copiedIncludes = copiedIncludes;
+    }
+
+    /**
+     * Returns the fully assembled, self-contained markdown for `path`.
+     */
+    async collect(path: NormalizedPath): Promise<string> {
+        const graph = await this.run.markdown.graph(path);
+
+        return (await this.dump(graph)).content;
+    }
+
+    // Preserves per-directive IncludeInfo fields (link, match, location) which
+    // may differ for same-path deps (e.g. same file included with different
+    // #hash fragments).
+    private dumpDep = async (dep: EntryGraphNode): Promise<HashedGraphNode> => {
+        const dumped = await this.dump(dep, true);
+
+        return {
+            ...dumped,
+            link: dep.link,
+            match: dep.match,
+            location: dep.location,
+        };
+    };
+
+    private async dump(graph: EntryGraph, write = false) {
+        const {run, config, processed, titles, svgList, copiedIncludes} = this;
+
+        const cached = processed.get(graph.path);
+        if (cached) {
+            return cached;
+        }
+
+        const deps: HashedGraphNode[] = await all(graph.deps.map(this.dumpDep));
+        const scheduler = new Scheduler([
+            config.hashIncludes && !config.mergeIncludes && rehashIncludes(run, deps),
+            config.mergeIncludes &&
+                mergeIncludes(run, deps, graph.content, config.mergeIncludesSourceMaps, !write),
+            config.mergeAutotitles && mergeAutotitles(run, titles, graph.assets),
+            config.mergeSvg && mergeSvg(run, svgList, graph.assets),
+        ]);
+
+        await scheduler.schedule(graph.path);
+
+        const content = await scheduler.process(graph.content);
+
+        const hash = config.hashIncludes ? rehashContent(content) : '';
+        const link = signlink(graph.path, hash);
+        const hashed = {...graph, deps, content, hash};
+
+        processed.set(graph.path, hashed);
+
+        if (copiedIncludes.has(link) || !write || config.mergeIncludes) {
+            return hashed;
+        }
+        copiedIncludes.add(link);
+
+        try {
+            run.logger.copy(join(run.input, graph.path), join(run.output, link));
+
+            // Add metadata frontmatter to include files.
+            // Without this, include files are written without YAML frontmatter,
+            // which causes non-deterministic output when the same file is both
+            // a TOC entry and an include in another file. The last writer wins,
+            // and if the include is written after the entry, metadata is lost.
+            // By ensuring both paths produce identical output, write order
+            // becomes irrelevant (see ADR-002: Multithreading Build).
+            // When these files are used as includes (e.g. md2html), the consumer
+            // must strip frontmatter before rendering the body (see output-html
+            // includes plugin).
+            const vars = run.vars.for(graph.path);
+            run.meta.addSystemVars(graph.path, vars.__system);
+            run.meta.addMetadata(graph.path, vars.__metadata);
+
+            // When the include file is also a TOC entry, resolve its VCS
+            // metadata (vcsPath, contributors, ...) here instead of relying
+            // on the entry's markdown Dump hook having run first. The same
+            // file may be processed as both a TOC entry and an include
+            // dependency concurrently (-j2); without this, the include dump
+            // could read `meta` before the entry hook populated `vcsPath`,
+            // producing non-deterministic frontmatter. `vcs.metadata` is
+            // idempotent (memoized, config gated, deterministic realpath),
+            // so resolving it here makes the include dump self-sufficient
+            // and write order irrelevant. Pure includes (not TOC entries)
+            // are skipped so their output keeps matching the entry path.
+            if (run.toc.isEntry(graph.path)) {
+                const vcsMeta = await run.vcs.metadata(graph.path, graph.deps.map(get('path')));
+                run.meta.add(graph.path, vcsMeta);
+                run.meta.addResources(graph.path, vcsMeta);
+            }
+
+            const includeMeta = await run.meta.dump(graph.path);
+            const lineWidth = config.disableMetaMaxLineWidth ? Infinity : undefined;
+            const contentWithMeta = addMetaFrontmatter(hashed.content, includeMeta, lineWidth);
+
+            await run.write(join(run.output, link), contentWithMeta, link !== graph.path);
+        } catch (error) {
+            run.logger.warn(`Unable to copy dependency ${graph.path}.`, error);
+        }
+
+        return hashed;
+    }
+}

--- a/src/commands/build/features/output-md/index.ts
+++ b/src/commands/build/features/output-md/index.ts
@@ -1,7 +1,5 @@
 import type {Build, Run} from '~/commands/build';
 import type {Command} from '~/core/config';
-import type {EntryGraph, EntryGraphNode} from '~/core/markdown';
-import type {HashedGraphNode} from './utils';
 
 import {join} from 'node:path';
 import {flow} from 'lodash';
@@ -15,17 +13,8 @@ import {getHooks as getMetaHooks} from '~/core/meta';
 import {getHooks as getLeadingHooks} from '~/core/leading';
 import {all, get, isMediaLink, shortLink} from '~/core/utils';
 
-import {
-    Scheduler,
-    addMetaFrontmatter,
-    getCustomCollectPlugins,
-    rehashContent,
-    signlink,
-} from './utils';
-import {mergeSvg} from './plugins/merge-svg';
-import {mergeAutotitles} from './plugins/merge-autotitles';
-import {mergeIncludes} from './plugins/merge-includes';
-import {rehashIncludes} from './plugins/resolve-deps';
+import {addMetaFrontmatter, getCustomCollectPlugins} from './utils';
+import {MarkdownCollector} from './collect';
 import {options} from './config';
 
 export type OutputMdArgs = {
@@ -142,131 +131,18 @@ export class OutputMd {
                     return meta;
                 });
 
-                // Recursively copy transformed markdown deps
+                // Recursively merge transformed markdown deps into a
+                // self-contained document (see MarkdownCollector).
                 getMarkdownHooks(run.markdown).Dump.tapPromise(
                     {name: 'Build.Md', stage: -Infinity},
                     async (vfile) => {
-                        const processed = new Map();
-                        const titles = new Map();
-                        const svgList = new Map();
+                        const collector = new MarkdownCollector(
+                            run,
+                            run.config.preprocess,
+                            copiedIncludes,
+                        );
 
-                        const config = run.config.preprocess;
-                        const graph = await run.markdown.graph(vfile.path);
-
-                        vfile.data = (await dump(graph)).content;
-
-                        // Preserve per-directive IncludeInfo fields (link, match,
-                        // location) which may differ for same-path deps
-                        // (e.g. same file included with different #hash fragments).
-                        async function dumpDep(dep: EntryGraphNode): Promise<HashedGraphNode> {
-                            const dumped = await dump(dep, true);
-                            return {
-                                ...dumped,
-                                link: dep.link,
-                                match: dep.match,
-                                location: dep.location,
-                            };
-                        }
-
-                        async function dump(graph: EntryGraph, write = false) {
-                            if (processed.has(graph.path)) {
-                                return processed.get(graph.path);
-                            }
-
-                            const deps: HashedGraphNode[] = await all(graph.deps.map(dumpDep));
-                            const scheduler = new Scheduler([
-                                config.hashIncludes &&
-                                    !config.mergeIncludes &&
-                                    rehashIncludes(run, deps),
-                                config.mergeIncludes &&
-                                    mergeIncludes(
-                                        run,
-                                        deps,
-                                        graph.content,
-                                        config.mergeIncludesSourceMaps,
-                                        !write,
-                                    ),
-                                config.mergeAutotitles &&
-                                    mergeAutotitles(run, titles, graph.assets),
-                                config.mergeSvg && mergeSvg(run, svgList, graph.assets),
-                            ]);
-
-                            await scheduler.schedule(graph.path);
-
-                            const content = await scheduler.process(graph.content);
-
-                            const hash = config.hashIncludes ? rehashContent(content) : '';
-                            const link = signlink(graph.path, hash);
-                            const hashed = {...graph, deps, content, hash};
-
-                            processed.set(graph.path, hashed);
-
-                            if (copiedIncludes.has(link) || !write || config.mergeIncludes) {
-                                return hashed;
-                            }
-                            copiedIncludes.add(link);
-
-                            try {
-                                run.logger.copy(
-                                    join(run.input, graph.path),
-                                    join(run.output, link),
-                                );
-
-                                // Add metadata frontmatter to include files.
-                                // Without this, include files are written without YAML frontmatter,
-                                // which causes non-deterministic output when the same file is both
-                                // a TOC entry and an include in another file. The last writer wins,
-                                // and if the include is written after the entry, metadata is lost.
-                                // By ensuring both paths produce identical output, write order
-                                // becomes irrelevant (see ADR-002: Multithreading Build).
-                                // When these files are used as includes (e.g. md2html), the consumer
-                                // must strip frontmatter before rendering the body (see output-html
-                                // includes plugin).
-                                const vars = run.vars.for(graph.path);
-                                run.meta.addSystemVars(graph.path, vars.__system);
-                                run.meta.addMetadata(graph.path, vars.__metadata);
-
-                                // When the include file is also a TOC entry, resolve its VCS
-                                // metadata (vcsPath, contributors, ...) here instead of relying
-                                // on the entry's markdown Dump hook having run first. The same
-                                // file may be processed as both a TOC entry and an include
-                                // dependency concurrently (-j2); without this, the include dump
-                                // could read `meta` before the entry hook populated `vcsPath`,
-                                // producing non-deterministic frontmatter. `vcs.metadata` is
-                                // idempotent (memoized, config gated, deterministic realpath),
-                                // so resolving it here makes the include dump self-sufficient
-                                // and write order irrelevant. Pure includes (not TOC entries)
-                                // are skipped so their output keeps matching the entry path.
-                                if (run.toc.isEntry(graph.path)) {
-                                    const vcsMeta = await run.vcs.metadata(
-                                        graph.path,
-                                        graph.deps.map(get('path')),
-                                    );
-                                    run.meta.add(graph.path, vcsMeta);
-                                    run.meta.addResources(graph.path, vcsMeta);
-                                }
-
-                                const includeMeta = await run.meta.dump(graph.path);
-                                const lineWidth = config.disableMetaMaxLineWidth
-                                    ? Infinity
-                                    : undefined;
-                                const contentWithMeta = addMetaFrontmatter(
-                                    hashed.content,
-                                    includeMeta,
-                                    lineWidth,
-                                );
-
-                                await run.write(
-                                    join(run.output, link),
-                                    contentWithMeta,
-                                    link !== graph.path,
-                                );
-                            } catch (error) {
-                                run.logger.warn(`Unable to copy dependency ${graph.path}.`, error);
-                            }
-
-                            return hashed;
-                        }
+                        vfile.data = await collector.collect(vfile.path);
                     },
                 );
 

--- a/src/commands/build/index.ts
+++ b/src/commands/build/index.ts
@@ -48,6 +48,7 @@ import {TocFiltering} from './features/toc-filtering';
 import {NeuroExpert} from './features/neuro-expert';
 import {Themer} from './features/themer';
 import {Analytics} from './features/analytics';
+import {Llms} from './features/llms';
 
 export type * from './types';
 
@@ -133,6 +134,8 @@ export class Build extends BaseProgram<BuildConfig, BuildArgs> {
 
     readonly analytics = new Analytics();
 
+    readonly llms = new Llms();
+
     readonly options = [
         options.input('./'),
         options.output({required: true}),
@@ -190,6 +193,7 @@ export class Build extends BaseProgram<BuildConfig, BuildArgs> {
         this.skipHtml,
         this.neuroExpert,
         this.analytics,
+        this.llms,
         new GenericIncluderExtension(),
         new OpenapiIncluderExtension(),
         new LocalSearchExtension(),

--- a/src/commands/build/types.ts
+++ b/src/commands/build/types.ts
@@ -22,6 +22,7 @@ import type {CustomResourcesArgs, CustomResourcesConfig} from './features/custom
 import type {TocFilteringArgs, TocFilteringConfig} from './features/toc-filtering';
 import type {ThemerArgs, ThemerConfig} from './features/themer';
 import type {WatchArgs, WatchConfig} from './features/watch';
+import type {LlmsArgs, LlmsConfig} from './features/llms';
 import type {OutputFormat} from './config';
 import type {TransformConfig} from './run';
 import type {EntryService, LeadingData, MarkdownData, PageData} from './services/entry';
@@ -126,7 +127,8 @@ export type BuildArgs = ProgramArgs &
             VcsArgs &
             WorkerArgs &
             WatchArgs &
-            ThemerArgs
+            ThemerArgs &
+            LlmsArgs
     >;
 
 export type BuildRawConfig = BaseArgs &
@@ -146,7 +148,8 @@ export type BuildRawConfig = BaseArgs &
     PreprocessConfig &
     WatchConfig &
     ThemerConfig &
-    NeuroExpertConfig;
+    NeuroExpertConfig &
+    LlmsConfig;
 
 export type BuildConfig = Config<
     BaseArgs &
@@ -171,6 +174,7 @@ export type BuildConfig = Config<
         WatchConfig &
         ThemerConfig &
         NeuroExpertConfig &
+        LlmsConfig &
         ContentConfig
 >;
 

--- a/tests/e2e/__snapshots__/llms.spec.ts.snap
+++ b/tests/e2e/__snapshots__/llms.spec.ts.snap
@@ -1,0 +1,257 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`llms.txt > generates llms.txt and llms-full.txt for md and html > filelist 1`] = `
+"[
+  ".yfm",
+  "api.md",
+  "index.md",
+  "llms-full.txt",
+  "llms.txt",
+  "start.md",
+  "toc.yaml"
+]"
+`;
+
+exports[`llms.txt > generates llms.txt and llms-full.txt for md and html > filelist 2`] = `
+"[
+  ".yfm",
+  "api.html",
+  "index.html",
+  "llms-full.txt",
+  "llms.txt",
+  "start.html",
+  "toc.js"
+]"
+`;
+
+exports[`llms.txt > generates llms.txt and llms-full.txt for md and html 1`] = `
+"allowHtml: true
+"
+`;
+
+exports[`llms.txt > generates llms.txt and llms-full.txt for md and html 2`] = `
+"---
+metadata:
+  - name: generator
+    content: Diplodoc Platform vDIPLODOC-VERSION
+description: Full reference of the public HTTP endpoints.
+vcsPath: api.md
+---
+
+# API Reference
+
+## GET /things
+
+Returns the list of things.
+"
+`;
+
+exports[`llms.txt > generates llms.txt and llms-full.txt for md and html 3`] = `
+"---
+metadata:
+  - name: generator
+    content: Diplodoc Platform vDIPLODOC-VERSION
+title: Overview
+description: What this product is and how to get started.
+vcsPath: index.md
+---
+
+# Overview
+
+Welcome to **My Product** — the documentation home page.
+"
+`;
+
+exports[`llms.txt > generates llms.txt and llms-full.txt for md and html 4`] = `
+"# My Product
+
+# Overview
+
+Welcome to **My Product** — the documentation home page.
+
+# Getting Started
+
+Run the installer and create your first project.
+
+## Requirements
+
+- Node.js 18+
+- 2 GB RAM
+
+# API Reference
+
+## GET /things
+
+Returns the list of things.
+"
+`;
+
+exports[`llms.txt > generates llms.txt and llms-full.txt for md and html 5`] = `
+"# My Product
+
+- [Overview](index.md): What this product is and how to get started.
+- [Getting Started](start.md): Install the product and build your first project.
+- [API Reference](api.md): Full reference of the public HTTP endpoints.
+"
+`;
+
+exports[`llms.txt > generates llms.txt and llms-full.txt for md and html 6`] = `
+"---
+metadata:
+  - name: generator
+    content: Diplodoc Platform vDIPLODOC-VERSION
+description: Install the product and build your first project.
+vcsPath: start.md
+---
+
+# Getting Started
+
+Run the installer and create your first project.
+
+<!-- source: _includes/requirements.md -->
+## Requirements
+
+- Node.js 18+
+- 2 GB RAM
+<!-- endsource: _includes/requirements.md -->
+"
+`;
+
+exports[`llms.txt > generates llms.txt and llms-full.txt for md and html 7`] = `
+"title: My Product
+href: index.md
+items:
+  - name: Getting Started
+    href: start.md
+  - name: API Reference
+    href: api.md
+path: toc.yaml
+"
+`;
+
+exports[`llms.txt > generates llms.txt and llms-full.txt for md and html 8`] = `
+"allowHtml: true
+"
+`;
+
+exports[`llms.txt > generates llms.txt and llms-full.txt for md and html 9`] = `
+"<!DOCTYPE html>
+<html lang="ru" dir="ltr">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <base href="./" />
+        <title>API Reference | My Product</title>
+        <meta name="generator" content="Diplodoc Platform vDIPLODOC-VERSION">
+        <meta name="description" content="Full reference of the public HTTP endpoints.">
+        <style type="text/css">html, body {min-height:100vh; height:100vh;}</style>
+    </head>
+    <body class="g-root g-root_theme_light">
+        <div id="root"></div>
+        <script type="application/json" id="diplodoc-state">
+            {"data":{"leading":false,"html":"&lt;h2 id=\\"get-/things\\"&gt;&lt;a href=\\"api.html#get-/things\\" class=\\"yfm-anchor yfm-clipboard-anchor\\" aria-hidden=\\"true\\"&gt;&lt;span class=\\"visually-hidden\\" data-no-index=\\"true\\"&gt;GET /things&lt;/span&gt;&lt;/a&gt;GET /things&lt;/h2&gt;/n&lt;p&gt;Returns the list of things.&lt;/p&gt;/n","meta":{"metadata":[{"name":"generator","content":"Diplodoc Platform vDIPLODOC-VERSION"},{"name":"description","content":"Full reference of the public HTTP endpoints."}],"description":"Full reference of the public HTTP endpoints.","vcsPath":"api.md"},"headings":[{"title":"GET /things","href":"api.html#get-/things","level":2}],"title":"API Reference"},"router":{"pathname":"api","depth":1,"base":"./"},"lang":"ru","langs":["ru"],"viewerInterface":{"toc":true,"search":true,"feedback":true}}
+        </script>
+        <script type="application/javascript">
+            const data = document.querySelector('script#diplodoc-state');
+            window.__DATA__ = JSON.parse((function unescape(string) {
+                return string.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+              })(data.innerText));
+            window.STATIC_CONTENT = false;
+        </script>
+        <script type="application/javascript" defer src="toc.js"></script>
+    </body>
+</html>"
+`;
+
+exports[`llms.txt > generates llms.txt and llms-full.txt for md and html 10`] = `
+"<!DOCTYPE html>
+<html lang="ru" dir="ltr">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <base href="./" />
+        <title>Overview | My Product</title>
+        <meta name="generator" content="Diplodoc Platform vDIPLODOC-VERSION">
+        <meta name="description" content="What this product is and how to get started.">
+        <style type="text/css">html, body {min-height:100vh; height:100vh;}</style>
+    </head>
+    <body class="g-root g-root_theme_light">
+        <div id="root"></div>
+        <script type="application/json" id="diplodoc-state">
+            {"data":{"leading":false,"html":"&lt;p&gt;Welcome to &lt;strong&gt;My Product&lt;/strong&gt; — the documentation home page.&lt;/p&gt;/n","meta":{"metadata":[{"name":"generator","content":"Diplodoc Platform vDIPLODOC-VERSION"},{"name":"description","content":"What this product is and how to get started."}],"title":"Overview","description":"What this product is and how to get started.","vcsPath":"index.md"},"headings":[],"title":"Overview"},"router":{"pathname":"index","depth":1,"base":"./"},"lang":"ru","langs":["ru"],"viewerInterface":{"toc":true,"search":true,"feedback":true}}
+        </script>
+        <script type="application/javascript">
+            const data = document.querySelector('script#diplodoc-state');
+            window.__DATA__ = JSON.parse((function unescape(string) {
+                return string.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+              })(data.innerText));
+            window.STATIC_CONTENT = false;
+        </script>
+        <script type="application/javascript" defer src="toc.js"></script>
+    </body>
+</html>"
+`;
+
+exports[`llms.txt > generates llms.txt and llms-full.txt for md and html 11`] = `
+"# My Product
+
+# Overview
+
+Welcome to **My Product** — the documentation home page.
+
+# Getting Started
+
+Run the installer and create your first project.
+
+## Requirements
+
+- Node.js 18+
+- 2 GB RAM
+
+# API Reference
+
+## GET /things
+
+Returns the list of things.
+"
+`;
+
+exports[`llms.txt > generates llms.txt and llms-full.txt for md and html 12`] = `
+"# My Product
+
+- [Overview](index.html): What this product is and how to get started.
+- [Getting Started](start.html): Install the product and build your first project.
+- [API Reference](api.html): Full reference of the public HTTP endpoints.
+"
+`;
+
+exports[`llms.txt > generates llms.txt and llms-full.txt for md and html 13`] = `
+"<!DOCTYPE html>
+<html lang="ru" dir="ltr">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <base href="./" />
+        <title>Getting Started | My Product</title>
+        <meta name="generator" content="Diplodoc Platform vDIPLODOC-VERSION">
+        <meta name="description" content="Install the product and build your first project.">
+        <style type="text/css">html, body {min-height:100vh; height:100vh;}</style>
+    </head>
+    <body class="g-root g-root_theme_light">
+        <div id="root"></div>
+        <script type="application/json" id="diplodoc-state">
+            {"data":{"leading":false,"html":"&lt;p&gt;Run the installer and create your first project.&lt;/p&gt;/n&lt;h2 id=\\"requirements\\"&gt;&lt;a href=\\"start.html#requirements\\" class=\\"yfm-anchor yfm-clipboard-anchor\\" aria-hidden=\\"true\\"&gt;&lt;span class=\\"visually-hidden\\" data-no-index=\\"true\\"&gt;Requirements&lt;/span&gt;&lt;/a&gt;Requirements&lt;/h2&gt;/n&lt;ul&gt;/n&lt;li&gt;Node.js 18+&lt;/li&gt;/n&lt;li&gt;2 GB RAM&lt;/li&gt;/n&lt;/ul&gt;/n","meta":{"metadata":[{"name":"generator","content":"Diplodoc Platform vDIPLODOC-VERSION"},{"name":"description","content":"Install the product and build your first project."}],"description":"Install the product and build your first project.","vcsPath":"start.md"},"headings":[{"title":"Requirements","href":"start.html#requirements","level":2}],"title":"Getting Started"},"router":{"pathname":"start","depth":1,"base":"./"},"lang":"ru","langs":["ru"],"viewerInterface":{"toc":true,"search":true,"feedback":true}}
+        </script>
+        <script type="application/javascript">
+            const data = document.querySelector('script#diplodoc-state');
+            window.__DATA__ = JSON.parse((function unescape(string) {
+                return string.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+              })(data.innerText));
+            window.STATIC_CONTENT = false;
+        </script>
+        <script type="application/javascript" defer src="toc.js"></script>
+    </body>
+</html>"
+`;
+
+exports[`llms.txt > generates llms.txt and llms-full.txt for md and html 14`] = `"window.__DATA__.data.toc = {"title":"My Product","href":"index.html","items":[{"name":"Getting Started","href":"start.html","id":"UUID"},{"name":"API Reference","href":"api.html","id":"UUID"}],"path":"toc.yaml","id":"UUID"};"`;

--- a/tests/e2e/llms.spec.ts
+++ b/tests/e2e/llms.spec.ts
@@ -1,0 +1,24 @@
+import {describe, test} from 'vitest';
+
+import {TestAdapter, compareDirectories, getTestPaths} from '../fixtures';
+
+describe('llms.txt', () => {
+    // Builds the same fixture in both md and html with `--llms` (variant B):
+    //   - md  output -> `${outputPath}`      (llms-full.txt has includes merged)
+    //   - html output -> `${outputPath}-html` (llms-full.txt keeps include directives)
+    // The fixture also has per-page frontmatter descriptions (surfaced in
+    // llms.txt) and a `when: showBeta` page that the default version filters
+    // out — proving the artifacts stay consistent with the built "version".
+    test('generates llms.txt and llms-full.txt for md and html', async () => {
+        const {inputPath, outputPath} = getTestPaths('mocks/llms');
+
+        await TestAdapter.testBuildPass(inputPath, outputPath, {
+            md2md: true,
+            md2html: true,
+            args: '--llms',
+        });
+
+        await compareDirectories(outputPath);
+        await compareDirectories(`${outputPath}-html`);
+    });
+});

--- a/tests/mocks/llms/input/.yfm
+++ b/tests/mocks/llms/input/.yfm
@@ -1,0 +1,1 @@
+allowHtml: true

--- a/tests/mocks/llms/input/_includes/requirements.md
+++ b/tests/mocks/llms/input/_includes/requirements.md
@@ -1,0 +1,4 @@
+## Requirements
+
+- Node.js 18+
+- 2 GB RAM

--- a/tests/mocks/llms/input/api.md
+++ b/tests/mocks/llms/input/api.md
@@ -1,0 +1,9 @@
+---
+description: Full reference of the public HTTP endpoints.
+---
+
+# API Reference
+
+## GET /things
+
+Returns the list of things.

--- a/tests/mocks/llms/input/beta.md
+++ b/tests/mocks/llms/input/beta.md
@@ -1,0 +1,4 @@
+# Beta Feature
+
+This page is gated behind `when: showBeta` and must NOT appear in the llms
+artifacts for the default (showBeta = false) version.

--- a/tests/mocks/llms/input/index.md
+++ b/tests/mocks/llms/input/index.md
@@ -1,0 +1,8 @@
+---
+title: Overview
+description: What this product is and how to get started.
+---
+
+# Overview
+
+Welcome to **My Product** — the documentation home page.

--- a/tests/mocks/llms/input/presets.yaml
+++ b/tests/mocks/llms/input/presets.yaml
@@ -1,0 +1,2 @@
+default:
+  showBeta: false

--- a/tests/mocks/llms/input/start.md
+++ b/tests/mocks/llms/input/start.md
@@ -1,0 +1,9 @@
+---
+description: Install the product and build your first project.
+---
+
+# Getting Started
+
+Run the installer and create your first project.
+
+{% include [Requirements](_includes/requirements.md) %}

--- a/tests/mocks/llms/input/toc.yaml
+++ b/tests/mocks/llms/input/toc.yaml
@@ -1,0 +1,11 @@
+title: My Product
+href: index.md
+
+items:
+  - name: Getting Started
+    href: start.md
+  - name: API Reference
+    href: api.md
+  - name: Beta Feature
+    href: beta.md
+    when: showBeta


### PR DESCRIPTION
## What

Adds an opt-in `--llms` build feature that emits, per toc, two artifacts
following the [llmstxt.org](https://llmstxt.org) spec:

- **`llms.txt`** — a compact index: `# <toc title>` + per-entry links with
  frontmatter descriptions.
- **`llms-full.txt`** — the whole doc as one self-contained markdown file.

Works for both `md` and `html` output.

## Design

- Runs in `AfterAnyRun` over the **already-filtered** toc, so the artifacts
  match the single-source "version" being built (conditional / hidden pages
  don't leak in).
- Index links point to the real output file: original href for `md`,
  `.html` for `html`.
- `llms-full.txt` is assembled as **fully self-contained markdown** (all
  includes merged), identical for md and html.

To avoid an md/html fork and keep one source of truth, `OutputMd`'s per-page
assembly was extracted into a reusable `MarkdownCollector`
(`output-md/collect.ts`). `OutputMd` delegates to it; `Llms` reuses it with a
`SELF_CONTAINED` preset.

`llms.txt` / `llms-full.txt` are excluded from `build-content-map` content
hashes.
