### PR TITLE
feat: add openapi companion DOCSTOOLS-5791

### DIFF
--- a/adr/ADR-007-openapi-companions.md
+++ b/adr/ADR-007-openapi-companions.md
@@ -1,0 +1,116 @@
+# ADR-007: OpenAPI companions (`*.openapi.json`)
+
+Status: accepted.
+
+This document captures the end-to-end contract of the **OpenAPI companion** feature — building
+and serving a "cleaned" OpenAPI JSON specification next to the leading page of a section generated
+by the `openapi` includer. This is the canonical ADR; the other repositories carry wrapper ADRs
+that link back here:
+
+- OpenAPI extension: `extensions/openapi/adr/ADR-003-openapi-companions.md`;
+- Viewer (`docs-viewer-external`): `docs/ADR-006-openapi-companions.md`.
+
+The feature mirrors the viewer's source-companions ADR (ADR-005), but for OpenAPI: instead of
+serving the raw `.md`/`.yaml`, it serves a file **generated at build time**, named after the
+source spec (`petstore.yaml` -> `petstore.openapi.json`).
+
+Example: the leading page `https://host/proj/api/` is accompanied by
+`https://host/proj/api/petstore.openapi.json` (the exact name comes from the build manifest).
+
+## Motivation
+
+- Machine-readable access to the spec (LLM/codegen/diffs) without parsing HTML or the JSON embedded
+  into the page.
+- The spec must be **cleaned exactly like the section**: endpoints removed by the `filter`
+  parameter and everything marked `x-hidden` must be gone.
+- Huge specs (tens of MB) cannot be inlined into the page — a link mode is required.
+
+## The three parts of the task
+
+### 1. `renderMode` and `maxOpenapiIncludeInlineSize` (openapi extension)
+
+`leadingPage.spec.renderMode` gains a third value — `link`:
+
+| renderMode | Leading page behavior                                                  |
+| ---------- | ---------------------------------------------------------------------- |
+| `inline`   | (default) the spec is embedded into the page via `{% cut %}`           |
+| `hidden`   | the spec is not shown and no companion file is created                 |
+| `link`     | instead of inlining, a link to the `*.openapi.json` companion is added |
+
+The build parameter `maxOpenapiIncludeInlineSize` (default `100K`, hard cap `1M`, `0` = always
+link): if the serialized spec is larger than the limit and `renderMode: inline`, the mode is
+**automatically** switched to `link` with an INFO-level log. `hidden` is never changed. If the
+companion file ends up not being created (see parts 2/3), `link` degrades back to `inline` to avoid
+a dead link.
+
+The decision and serialization live in `extensions/openapi/src/includer`: `companion.ts`
+(`buildCompanionDocument` / `serializeCompanionDocument`) and `resolveCompanion()` in `index.ts`.
+The companion is built from the partially dereferenced document (schemas stay as `$ref`, so
+recursive schemas remain acyclic and serializable), filtered down to the operations actually
+rendered, cleaned of `x-hidden`, and unreachable `components.schemas` are pruned. Serialization is
+minified (`JSON.stringify` without indentation). The file name is derived from the includer input
+(`companionFilename` in `includer/utils.ts`).
+
+### 2. `ai.openapiCompanions` (yfm-config / CLI flag)
+
+The new `ai` config section controls **whether** the companion file is created and for which build
+formats:
+
+| Value   | md2md | md2html | Note             |
+| ------- | ----- | ------- | ---------------- |
+| `true`  | yes   | yes     |                  |
+| `'md'`  | yes   | no      | **default**      |
+| `false` | no    | no      | feature disabled |
+
+The CLI flag `--ai-openapi-companions` is a **boolean** override (`true` / `--no-...` = `false`).
+It wins only when explicitly passed; otherwise the `.yfm` value is preserved as-is so it stays
+overridable from config (same approach as `multilineTermDefinitions`). The default (`'md'`) is
+**not** applied in the CLI: it is owned by the openapi extension
+(`DEFAULT_OPENAPI_COMPANIONS_MODE`), the single consumer of this value — keeping the default in one
+place. Implementation: `ai.openapiCompanions` in `yfm-schema.yaml`, options in
+`commands/build/config.ts` (`resolveAiConfig`), the `AiConfig` type in `commands/build/types.ts`.
+
+### 3. Writing the file and the build manifest
+
+- Emission gating (ai + outputFormat + `maxOpenapiIncludeSize`) is done **inside the includer**, so
+  a companion only appears in `files` when it actually has to be written. There is therefore no
+  separate flag check in the CLI extension or the manifest feature.
+- The CLI wrapper `src/extensions/openapi/index.ts` writes `*.openapi.json` verbatim (no oversize
+  stub logic — that applies only to `.md` pages) and registers the write for the manifest
+  (`registerOpenapiCompanion`, stored on `run`). The companion always sits next to the generated
+  `index.md`, so its leading page is the sibling `index` (the leading page cannot be recovered by
+  stripping the suffix, because the companion name is derived from the spec).
+- The build-manifest feature adds an `openapiCompanions` array to `yfm-build-manifest.json`:
+
+```json
+{
+  "openapiCompanions": [
+    {"leadingPage": "ru/api/index", "companionPath": "ru/api/petstore.openapi.json"}
+  ]
+}
+```
+
+`maxOpenapiIncludeSize`: if the companion is larger than the limit, the file is **not created**
+(the viewer returns 404) and there is no manifest entry.
+
+## Contract for the viewer
+
+- The companion file lives in the same S3 tree as the built md2md sources:
+  `prefix/rev/<revision>/<lang>/<companionPath>`.
+- The manifest (`openapiCompanions`) is the source of truth for the html comment on the page — the
+  viewer must use the exact `companionPath` (the file name is derived from the spec and cannot be
+  reconstructed from the leading page).
+- Access to the companion is restricted the same way as the leading page (`Restricted-Access`).
+
+## Consequences / edge cases
+
+- The default `ai.openapiCompanions: 'md'` means md2html does not write a companion by default;
+  large specs in HTML stay `inline` (backward compatibility) until they hit
+  `maxOpenapiIncludeSize` (then a stub).
+- `renderMode: link` without a companion file → fallback to `inline` (no dead links).
+- Only `components.schemas` are pruned; other groups (`securitySchemes`, `parameters`, …) are kept
+  in full because they are referenced by name, not via `$ref`.
+
+```
+
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.44.0",
       "license": "MIT",
       "dependencies": {
-        "@diplodoc/client": "^5.7.9",
+        "@diplodoc/client": "^5.7.11",
         "@diplodoc/liquid": "^1.5.2",
         "@diplodoc/transform": "^4.75.4",
         "@diplodoc/translation": "^1.7.24",
@@ -48,7 +48,7 @@
         "@diplodoc/infra": "2.0.5",
         "@diplodoc/latex-extension": "^1.4.1",
         "@diplodoc/mermaid-extension": "^2.1.3",
-        "@diplodoc/openapi-extension": "^5.1.3",
+        "@diplodoc/openapi-extension": "^5.2.1",
         "@diplodoc/page-constructor-extension": "^0.13.4",
         "@diplodoc/search-extension": "^3.0.5",
         "@diplodoc/tsconfig": "^1.0.2",
@@ -1681,9 +1681,9 @@
       }
     },
     "node_modules/@diplodoc/client": {
-      "version": "5.7.9",
-      "resolved": "https://registry.npmjs.org/@diplodoc/client/-/client-5.7.9.tgz",
-      "integrity": "sha512-v+vJZ8UPkl4yjoQCIJhggoUBL/NFNBOby9DCfXipKJkTXm+viElIsG1BaVWK7jNW6XljwLJgv0rLfaUkqpzmYg==",
+      "version": "5.7.11",
+      "resolved": "https://registry.npmjs.org/@diplodoc/client/-/client-5.7.11.tgz",
+      "integrity": "sha512-FGCXv2Ycr8/mZrw7Qe5nLFjlp4R/8JFfi6KKMSLsE0+6s9IJgYC9DVxfMaMNKHtlexPXdHyeksAZjOdkeccDnw==",
       "license": "ISC",
       "engines": {
         "node": ">=24",
@@ -1867,13 +1867,13 @@
       }
     },
     "node_modules/@diplodoc/openapi-extension": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@diplodoc/openapi-extension/-/openapi-extension-5.1.3.tgz",
-      "integrity": "sha512-07PKNiXK5wGT3cU2fOSus2gCGiPWN7hSmeeiwqtpvQBV8jCnpAwo+oOjgxJINCxDiV259yeS7io//WTwE+MHvA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@diplodoc/openapi-extension/-/openapi-extension-5.2.1.tgz",
+      "integrity": "sha512-pikchO56cPL3sbF60mo8P1hicbQ82sE7F+FE/KL50XtOmzbYjkVzOpByrG1LV/Ff/WdDJrofyNNLOQkW5ErWnA==",
       "dev": true,
       "dependencies": {
         "@apidevtools/swagger-parser": "^12.0.0",
-        "@diplodoc/liquid": "^1.3.4",
+        "@diplodoc/liquid": "^1.5.2",
         "@vitest/coverage-v8": "^3.2.4",
         "bem-cn-lite": "^4.1.0",
         "http-status-codes": "^2.2.0",
@@ -1883,7 +1883,7 @@
         "slugify": "^1.6.6"
       },
       "engines": {
-        "node": ">=22",
+        "node": ">=24",
         "npm": ">=11.5.1"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     ]
   },
   "dependencies": {
-    "@diplodoc/client": "^5.7.9",
+    "@diplodoc/client": "^5.7.11",
     "@diplodoc/liquid": "^1.5.2",
     "@diplodoc/transform": "^4.75.4",
     "@diplodoc/translation": "^1.7.24",
@@ -111,7 +111,7 @@
     "@diplodoc/infra": "2.0.5",
     "@diplodoc/latex-extension": "^1.4.1",
     "@diplodoc/mermaid-extension": "^2.1.3",
-    "@diplodoc/openapi-extension": "^5.1.3",
+    "@diplodoc/openapi-extension": "^5.2.1",
     "@diplodoc/page-constructor-extension": "^0.13.4",
     "@diplodoc/search-extension": "^3.0.5",
     "@diplodoc/tsconfig": "^1.0.2",

--- a/schemas/toc-schema.yaml
+++ b/schemas/toc-schema.yaml
@@ -179,7 +179,7 @@ definitions:
             properties:
               renderMode:
                 type: string
-                enum: ['inline', 'hidden']
+                enum: ['inline', 'hidden', 'link']
       tags:
         type: object
         additionalProperties:

--- a/schemas/yfm-schema.yaml
+++ b/schemas/yfm-schema.yaml
@@ -400,12 +400,41 @@ properties:
       maxAssetSize:
         $ref: '#/definitions/FileSize'
         description: Maximum asset file size. 0 disables the check.
+      maxOpenapiIncludeSize:
+        $ref: '#/definitions/FileSize'
+        description: >
+          Maximum size of a generated OpenAPI page (and its spec companion).
+          Pages above the limit are replaced with a stub; companions above the
+          limit are not emitted. 0 disables the check.
+      maxOpenapiIncludeInlineSize:
+        $ref: '#/definitions/FileSize'
+        description: >
+          Maximum size of the OpenAPI specification embedded inline on a leading page.
+          If exceeded, 'leadingPage.spec.renderMode: inline' auto-switches to 'link'.
+          Default: 100K. Hard-capped at 1M. 0 means always render the spec as a link.
       multilineTermDefinitions:
         type: boolean
         description: >
           Allow term definitions to span multiple lines.
           When enabled, a definition continues until the next [*key]: or end of block.
           Default: false.
+    additionalProperties: false
+
+  # ── AI / companions ────────────────────────────────────────────────
+  ai:
+    type: object
+    properties:
+      openapiCompanions:
+        oneOf:
+          - type: boolean
+          - type: string
+            enum: ['md']
+        description: >
+          Emit standalone OpenAPI spec companions (*.openapi.json, name derived from the
+          source spec) next to generated OpenAPI leading pages.
+          true — emit in both md2md and md2html;
+          'md' — emit only in md2md (default);
+          false — disabled.
     additionalProperties: false
 
   # ── TOC filtering ──────────────────────────────────────────────────

--- a/scripts/assets.js
+++ b/scripts/assets.js
@@ -5,6 +5,7 @@ const clientManifest = require('@diplodoc/client/manifest');
 
 const ASSETS_PATH = resolve(__dirname, '..', 'assets');
 const CLIENT_PATH = dirname(require.resolve('@diplodoc/client/manifest'));
+const HIGHLIGHT_STYLES_PATH = dirname(require.resolve('highlight.js/styles/github.css'));
 const MERMAID_PATH = dirname(require.resolve('@diplodoc/mermaid-extension/runtime'));
 const LATEX_PATH = dirname(require.resolve('@diplodoc/latex-extension/runtime'));
 const SEARCH_PATH = dirname(require.resolve('@diplodoc/search-extension/worker'));
@@ -47,4 +48,17 @@ for (const lang of langs) {
 
 for (const file of assets) {
     copyFileSync(join(CLIENT_PATH, file), join(ASSETS_PATH, file));
+}
+
+// Bundle highlight.js theme styles so the CLI ships them itself (see themer/constants.ts).
+// Subdirectories (e.g. base16/) are preserved because theme names may contain a slash.
+const highlightStyles = glob('**/*.css', {
+    cwd: HIGHLIGHT_STYLES_PATH,
+    ignore: ['**/*.min.css'],
+});
+
+for (const file of highlightStyles) {
+    const dest = join(ASSETS_PATH, 'highlight-styles', file);
+    mkdirSync(dirname(dest), {recursive: true});
+    copyFileSync(join(HIGHLIGHT_STYLES_PATH, file), dest);
 }

--- a/src/commands/build/config.spec.ts
+++ b/src/commands/build/config.spec.ts
@@ -1,0 +1,42 @@
+import type {BuildArgs, BuildConfig} from './types';
+
+import {describe, expect, it} from 'vitest';
+
+import {resolveAiConfig} from './config';
+
+const config = (ai?: {openapiCompanions?: boolean | 'md'}) => ({ai}) as unknown as BuildConfig;
+const args = (value?: unknown) =>
+    (value === undefined ? {} : {aiOpenapiCompanions: value}) as unknown as BuildArgs;
+
+describe('resolveAiConfig', () => {
+    it('keeps the .yfm value when the CLI flag is not passed', () => {
+        expect(resolveAiConfig(config({openapiCompanions: false}), args())).toEqual({
+            openapiCompanions: false,
+        });
+        expect(resolveAiConfig(config({openapiCompanions: true}), args())).toEqual({
+            openapiCompanions: true,
+        });
+        expect(resolveAiConfig(config({openapiCompanions: 'md'}), args())).toEqual({
+            openapiCompanions: 'md',
+        });
+    });
+
+    it('leaves the value undefined when neither flag nor config is set (extension applies default)', () => {
+        expect(resolveAiConfig(config(), args())).toEqual({openapiCompanions: undefined});
+    });
+
+    it('lets an explicit CLI flag override the .yfm value', () => {
+        // --ai-openapi-companions over `false`
+        expect(resolveAiConfig(config({openapiCompanions: false}), args(true))).toEqual({
+            openapiCompanions: true,
+        });
+        // --no-ai-openapi-companions over `true`
+        expect(resolveAiConfig(config({openapiCompanions: true}), args(false))).toEqual({
+            openapiCompanions: false,
+        });
+        // --no-ai-openapi-companions over `'md'`
+        expect(resolveAiConfig(config({openapiCompanions: 'md'}), args(false))).toEqual({
+            openapiCompanions: false,
+        });
+    });
+});

--- a/src/commands/build/config.ts
+++ b/src/commands/build/config.ts
@@ -1,4 +1,4 @@
-import type {BuildArgs, BuildConfig, ContentConfig} from './types';
+import type {AiConfig, BuildArgs, BuildConfig, ContentConfig} from './types';
 import type {ExtendedOption} from '~/core/config';
 
 import {ok} from 'node:assert';
@@ -195,6 +195,36 @@ const maxOpenapiIncludeSize = option({
     parser: fileSizeConverter({disableIfZero: true}),
 });
 
+const maxOpenapiIncludeInlineSize = option({
+    flags: '--max-openapi-include-inline-size <value>',
+    desc: `
+        Max size of the OpenAPI specification embedded inline on the leading page.
+        If the spec exceeds this size, 'leadingPage.spec.renderMode: inline' is
+        automatically switched to 'link' (a link to the *.openapi.json companion).
+        Use '0' to always render the spec as a link.
+        Default: 100K
+        Max size: 1M
+
+        Example:
+            {{PROGRAM}} build -i . -o ../build --max-openapi-include-inline-size '256K'
+    `,
+    default: '100K',
+    parser: fileSizeConverter({max: '1M'}),
+});
+
+const aiOpenapiCompanions = option({
+    flags: '--ai-openapi-companions',
+    desc: `
+        Emit standalone OpenAPI spec companions (*.openapi.json) next to generated
+        OpenAPI leading pages. When the flag is passed it is treated as a boolean override
+        of the 'ai.openapiCompanions' config value. When omitted, the config value is used
+        (default: 'md', i.e. emit only in md2md builds).
+
+        Example:
+            {{PROGRAM}} build -i . -o ../build --ai-openapi-companions
+    `,
+});
+
 const maxInlineSvgSize = option({
     flags: '--max-inline-svg-size <value>',
     desc: `
@@ -301,6 +331,26 @@ export function combineProps<C extends BuildConfig>(
     );
 
     return result;
+}
+
+/**
+ * Resolves the `ai` config group.
+ *
+ * `ai.openapiCompanions` is tri-state in config (`true | 'md' | false`), while the CLI flag is a
+ * plain boolean override. The flag wins ONLY when it is explicitly passed; otherwise the `.yfm`
+ * value is preserved as-is so it stays overridable from config (same approach as
+ * `multilineTermDefinitions`, see run.ts). The default (`'md'`) is intentionally NOT applied
+ * here — it is owned by the openapi extension (`DEFAULT_OPENAPI_COMPANIONS_MODE`), the single
+ * place that consumes this value, keeping the default in one location.
+ */
+export function resolveAiConfig<C extends BuildConfig>(config: C, args: BuildArgs): AiConfig {
+    const ai = (config.ai as Partial<AiConfig> | undefined) || {};
+
+    const argValue = defined('aiOpenapiCompanions', args);
+    const openapiCompanions =
+        argValue === null || argValue === undefined ? ai.openapiCompanions : Boolean(argValue);
+
+    return {...ai, openapiCompanions};
 }
 
 function getInterfaceProps<C extends BuildConfig>(config: C, args: BuildArgs) {
@@ -415,6 +465,7 @@ export function normalize<C extends BuildConfig>(config: C, args: BuildArgs) {
             'maxHtmlSize',
             'maxAssetSize',
             'maxOpenapiIncludeSize',
+            'maxOpenapiIncludeInlineSize',
             'multilineTermDefinitions',
         ],
         {
@@ -422,9 +473,12 @@ export function normalize<C extends BuildConfig>(config: C, args: BuildArgs) {
             maxHtmlSize,
             maxAssetSize,
             maxOpenapiIncludeSize,
+            maxOpenapiIncludeInlineSize,
             multilineTermDefinitions,
         },
     ) as ContentConfig;
+
+    config.ai = resolveAiConfig(config, args);
 
     if (feedbackUrl) {
         config.feedback = config.feedback || {};
@@ -471,5 +525,7 @@ export const options = {
     multilineTermDefinitions,
     addAlternateMeta,
     maxOpenapiIncludeSize,
+    maxOpenapiIncludeInlineSize,
+    aiOpenapiCompanions,
     idGenerator,
 };

--- a/src/commands/build/features/build-manifest/index.spec.ts
+++ b/src/commands/build/features/build-manifest/index.spec.ts
@@ -53,6 +53,32 @@ describe('Build manifest feature', () => {
         });
     });
 
+    describe('collectOpenapiCompanions method', () => {
+        const collect = (openapiCompanions: unknown) => {
+            const buildManifest = new BuildManifest();
+            // @ts-ignore - accessing private method for testing
+            return buildManifest.collectOpenapiCompanions({openapiCompanions});
+        };
+
+        it('returns an empty array when nothing was registered', () => {
+            expect(collect(undefined)).toEqual([]);
+            expect(collect([])).toEqual([]);
+        });
+
+        it('deduplicates by companion path and sorts deterministically', () => {
+            const result = collect([
+                {leadingPage: 'ru/b/index', companionPath: 'ru/b/index.openapi.json'},
+                {leadingPage: 'ru/a/index', companionPath: 'ru/a/index.openapi.json'},
+                {leadingPage: 'ru/a/index', companionPath: 'ru/a/index.openapi.json'},
+            ]);
+
+            expect(result).toEqual([
+                {leadingPage: 'ru/a/index', companionPath: 'ru/a/index.openapi.json'},
+                {leadingPage: 'ru/b/index', companionPath: 'ru/b/index.openapi.json'},
+            ]);
+        });
+    });
+
     describe('buildFileTrie method', () => {
         const createRun = (entries: string[]) =>
             ({

--- a/src/commands/build/features/build-manifest/index.ts
+++ b/src/commands/build/features/build-manifest/index.ts
@@ -1,5 +1,5 @@
 import type {Command} from '~/core/config';
-import type {Build, Run} from '~/commands/build';
+import type {Build, OpenapiCompanionEntry, Run} from '~/commands/build';
 import type {Redirects} from '../../services/redirects';
 
 import {join, parse} from 'node:path';
@@ -27,14 +27,6 @@ type FileTrie = {
 type FileTrieEntryPoint = {
     trie: FileTrie;
     tocMapping: Record<string, string>;
-};
-
-/** Maps a generated OpenAPI leading page to its standalone spec companion file. */
-type OpenapiCompanionEntry = {
-    /** Lang-relative path of the leading page (without extension), e.g. `ru/api/index`. */
-    leadingPage: string;
-    /** Lang-relative path of the companion file (name derived from the spec), e.g. `ru/api/petstore.openapi.json`. */
-    companionPath: string;
 };
 
 type BuildManifestFormat = {

--- a/src/commands/build/features/build-manifest/index.ts
+++ b/src/commands/build/features/build-manifest/index.ts
@@ -29,10 +29,19 @@ type FileTrieEntryPoint = {
     tocMapping: Record<string, string>;
 };
 
+/** Maps a generated OpenAPI leading page to its standalone spec companion file. */
+type OpenapiCompanionEntry = {
+    /** Lang-relative path of the leading page (without extension), e.g. `ru/api/index`. */
+    leadingPage: string;
+    /** Lang-relative path of the companion file (name derived from the spec), e.g. `ru/api/petstore.openapi.json`. */
+    companionPath: string;
+};
+
 type BuildManifestFormat = {
     fileTrie: FileTrieEntryPoint;
     yfmConfig: unknown;
     redirects: Redirects;
+    openapiCompanions?: OpenapiCompanionEntry[];
 };
 
 const MANIFEST_FILENAME = 'yfm-build-manifest.json';
@@ -79,11 +88,13 @@ export class BuildManifest {
                 const redirects = run.redirects.rawRedirects;
                 const fileTrie = this.buildFileTrie(run);
                 const yfmConfig = await this.readYfmConfig(run);
+                const openapiCompanions = this.collectOpenapiCompanions(run);
 
                 const manifest: BuildManifestFormat = {
                     redirects,
                     fileTrie,
                     yfmConfig,
+                    ...(openapiCompanions.length ? {openapiCompanions} : {}),
                 };
 
                 await run.write(
@@ -92,6 +103,33 @@ export class BuildManifest {
                     true,
                 );
             });
+    }
+
+    /**
+     * Reads OpenAPI companion entries recorded by the openapi includer extension during the run.
+     *
+     * No flag/format check is needed here: emission is gated upstream in the openapi includer
+     * (`ai.openapiCompanions` + `outputFormat` + size limits). The includer only returns a
+     * companion file when it should be written, the openapi CLI extension only registers entries
+     * for files it actually wrote, so `run.openapiCompanions` is already the gated set.
+     *
+     * Entries are deduplicated and sorted for deterministic manifest output.
+     */
+    private collectOpenapiCompanions(run: Run): OpenapiCompanionEntry[] {
+        const raw = (run as Run & {openapiCompanions?: OpenapiCompanionEntry[]}).openapiCompanions;
+
+        if (!Array.isArray(raw) || raw.length === 0) {
+            return [];
+        }
+
+        const byCompanionPath = new Map<string, OpenapiCompanionEntry>();
+        for (const entry of raw) {
+            byCompanionPath.set(entry.companionPath, entry);
+        }
+
+        return [...byCompanionPath.values()].sort((a, b) =>
+            a.companionPath.localeCompare(b.companionPath),
+        );
     }
 
     private async readYfmConfig(run: Run): Promise<unknown> {

--- a/src/commands/build/features/output-html/index.ts
+++ b/src/commands/build/features/output-html/index.ts
@@ -218,7 +218,12 @@ export class OutputHtml {
                 // TODO: we copy all files. Required to copy only used files.
                 // Look at the same copy process in output-md feature.
                 await run.copy(run.input, run.output, ['**/*.yaml', '**/*.md']);
-                await run.copy(ASSETS_FOLDER, run.bundlePath, ['search-extension/**']);
+                // `highlight-styles/**` are build-time inputs for theme.css generation only;
+                // they must not be shipped into every doc's `_bundle` (mirrors `search-extension/**`).
+                await run.copy(ASSETS_FOLDER, run.bundlePath, [
+                    'search-extension/**',
+                    'highlight-styles/**',
+                ]);
 
                 const assetsPath = join(run.input, '_assets');
                 if (run.exists(assetsPath)) {

--- a/src/commands/build/features/output-html/index.ts
+++ b/src/commands/build/features/output-html/index.ts
@@ -1,5 +1,5 @@
 import type {ConfigData, PreloadParams} from '@diplodoc/client/ssr';
-import type {Build, EntryData, PageData} from '~/commands/build';
+import type {Build, EntryData, PageData, Run} from '~/commands/build';
 import type {Toc, TocItem} from '~/core/toc';
 import type {LeadingPage} from '~/core/leading';
 
@@ -96,7 +96,11 @@ export class OutputHtml {
                     const template = new Template(vfile.path, state.lang, [__Entry__]);
                     template.setCspDisabled(Boolean(run.config.disableCsp));
 
-                    const html = await run.entry.page(template, state, toc.data);
+                    const html = injectOpenapiCompanionComment(
+                        run,
+                        vfile.path,
+                        await run.entry.page(template, state, toc.data),
+                    );
                     vfile.path = setExt(vfile.path, '.html');
                     vfile.format(() => html);
                     Object.assign(vfile.info, data);
@@ -248,6 +252,48 @@ export class OutputHtml {
                 );
             });
     }
+}
+
+/** Maps a generated OpenAPI leading page to its standalone spec companion file. */
+type OpenapiCompanionEntry = {
+    /** Lang-relative path of the leading page (without extension), e.g. `api/index`. */
+    leadingPage: string;
+    /** Lang-relative path of the companion file, e.g. `api/petstore.openapi.json`. */
+    companionPath: string;
+};
+
+/**
+ * Bakes the OpenAPI spec companion hint into the static leading page HTML.
+ *
+ * For md2md docs the viewer injects this comment at serve time, but md2html is served
+ * statically (no viewer), so the page itself must carry it. The companion is registered by
+ * the openapi includer wrapper on `run.openapiCompanions`, and only when a companion file is
+ * actually emitted (i.e. not for `renderMode: hidden`) — so the comment is render-mode
+ * dependent. HTML comments authored in Markdown are stripped during transform, hence the
+ * comment is injected straight into the rendered `<body>`.
+ */
+function injectOpenapiCompanionComment(run: Run, entryPath: NormalizedPath, html: string): string {
+    const companions = (run as Run & {openapiCompanions?: OpenapiCompanionEntry[]})
+        .openapiCompanions;
+
+    if (!Array.isArray(companions) || companions.length === 0) {
+        return html;
+    }
+
+    const pageNoExt = setExt(entryPath, '');
+    const entry = companions.find((companion) => companion.leadingPage === pageNoExt);
+
+    if (!entry) {
+        return html;
+    }
+
+    // The companion sits next to the leading page, so a relative file name is a valid link.
+    const target = basename(entry.companionPath);
+    const comment = `<!-- json-схема со спецификацией доступна по ссылке: ${target} -->`;
+
+    return html.includes('</body>')
+        ? html.replace('</body>', `        ${comment}\n    </body>`)
+        : `${html}\n${comment}`;
 }
 
 function getStateData(entry: EntryData): PageData {

--- a/src/commands/build/features/output-html/index.ts
+++ b/src/commands/build/features/output-html/index.ts
@@ -1,5 +1,5 @@
 import type {ConfigData, PreloadParams} from '@diplodoc/client/ssr';
-import type {Build, EntryData, PageData, Run} from '~/commands/build';
+import type {Build, EntryData, OpenapiCompanionEntry, PageData, Run} from '~/commands/build';
 import type {Toc, TocItem} from '~/core/toc';
 import type {LeadingPage} from '~/core/leading';
 
@@ -258,14 +258,6 @@ export class OutputHtml {
             });
     }
 }
-
-/** Maps a generated OpenAPI leading page to its standalone spec companion file. */
-type OpenapiCompanionEntry = {
-    /** Lang-relative path of the leading page (without extension), e.g. `api/index`. */
-    leadingPage: string;
-    /** Lang-relative path of the companion file, e.g. `api/petstore.openapi.json`. */
-    companionPath: string;
-};
 
 /**
  * Bakes the OpenAPI spec companion hint into the static leading page HTML.

--- a/src/commands/build/features/themer/constants.ts
+++ b/src/commands/build/features/themer/constants.ts
@@ -1,10 +1,15 @@
 import type {ColorVariant, UtilityColorKey} from './types';
 
-import {dirname} from 'node:path';
+import {existsSync} from 'node:fs';
+import {dirname, join} from 'node:path';
 
 export const ROOT = dirname(require.resolve('@diplodoc/cli/package'));
 
-export const HIGHLIGHT_STYLES_ROOT = dirname(require.resolve('highlight.js/styles/github.css'));
+const BUNDLED_HIGHLIGHT_STYLES_ROOT = join(ROOT, 'assets', 'highlight-styles');
+
+export const HIGHLIGHT_STYLES_ROOT = existsSync(BUNDLED_HIGHLIGHT_STYLES_ROOT)
+    ? BUNDLED_HIGHLIGHT_STYLES_ROOT
+    : dirname(require.resolve('highlight.js/styles/github.css'));
 
 export const THEME_CONFIG_FILENAME = 'theme.yaml';
 

--- a/src/commands/build/index.ts
+++ b/src/commands/build/index.ts
@@ -163,6 +163,8 @@ export class Build extends BaseProgram<BuildConfig, BuildArgs> {
         options.maxHtmlSize,
         options.maxAssetSize,
         options.maxOpenapiIncludeSize,
+        options.maxOpenapiIncludeInlineSize,
+        options.aiOpenapiCompanions,
         options.multilineTermDefinitions,
         options.idGenerator,
         options.strict,

--- a/src/commands/build/types.ts
+++ b/src/commands/build/types.ts
@@ -47,7 +47,26 @@ export type ContentConfig = {
     maxHtmlSize: number;
     maxAssetSize: number;
     maxOpenapiIncludeSize: number;
+    /**
+     * Max size (bytes) of the OpenAPI spec embedded inline on the leading page.
+     * If exceeded, `leadingPage.spec.renderMode: inline` auto-switches to `link`.
+     * Default 100K, hard-capped at 1M. 0 means always render as a link.
+     */
+    maxOpenapiIncludeInlineSize: number;
     multilineTermDefinitions: boolean;
+};
+
+/**
+ * Controls emission of the standalone OpenAPI spec companion (`*.openapi.json`):
+ *  - `true` — emit in both md2md and md2html;
+ *  - `'md'` — emit only in md2md (default);
+ *  - `false` — disabled.
+ *
+ * `undefined` means "not configured": the default (`'md'`) is owned and applied by the
+ * openapi extension (`DEFAULT_OPENAPI_COMPANIONS_MODE`), the single consumer of this value.
+ */
+export type AiConfig = {
+    openapiCompanions?: boolean | 'md';
 };
 
 export type {IDGeneratorStrategy};
@@ -88,6 +107,7 @@ type BaseConfig = {
     disableCsp?: boolean;
     pdfDebug: boolean;
     content: ContentConfig;
+    ai: AiConfig;
     codeHighlight?: CodeHighlightConfig | null;
     /**
      * Strategy for generating element IDs (tabs, terms, code blocks, etc.).

--- a/src/commands/build/types.ts
+++ b/src/commands/build/types.ts
@@ -69,6 +69,18 @@ export type AiConfig = {
     openapiCompanions?: boolean | 'md';
 };
 
+/** Maps a generated OpenAPI leading page to its standalone spec companion file. */
+export type OpenapiCompanionEntry = {
+    /** Lang-relative path of the leading page (without extension), e.g. `ru/api/index`. */
+    leadingPage: string;
+    /**
+     * Lang-relative path of the companion file. The file name is derived from the source spec
+     * (`petstore.yaml` -> `petstore.openapi.json`), so it is not necessarily `index.openapi.json`,
+     * e.g. `ru/api/petstore.openapi.json`. The viewer must use this exact path.
+     */
+    companionPath: string;
+};
+
 export type {IDGeneratorStrategy};
 
 type BaseConfig = {

--- a/src/extensions/openapi/index.spec.ts
+++ b/src/extensions/openapi/index.spec.ts
@@ -1,6 +1,7 @@
 import type {BuildConfig} from '~/commands/build';
 import type {FullTap} from 'tapable';
 
+import {join} from 'node:path';
 import {describe, expect, it, vi} from 'vitest';
 
 import {Build} from '~/commands/build';
@@ -18,6 +19,8 @@ vi.mock('@diplodoc/openapi-extension/includer', () => ({
         files: [
             {path: 'index.md', content: 'a'.repeat(200)},
             {path: 'endpoint.md', content: 'a'.repeat(50)},
+            // Companion name is derived from the source spec, so it is not `index.openapi.json`.
+            {path: 'petstore.openapi.json', content: '{"openapi":"3.0.0"}'},
         ],
     }),
 }));
@@ -34,6 +37,8 @@ describe('OpenAPI extension', () => {
                     maxOpenapiIncludeSize,
                 },
             } as unknown as BuildConfig);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (run as any).openapiCompanions = undefined;
 
             // Invoke BeforeAnyRun to register the includer hook
             const beforeAnyRunHook = getBaseHooks(build).BeforeAnyRun.taps.find(
@@ -59,7 +64,7 @@ describe('OpenAPI extension', () => {
                 await includerHook.fn(rawtoc, options, 'toc.yaml');
             }
 
-            return {writeSpy, warnSpy};
+            return {writeSpy, warnSpy, run};
         }
 
         it('should replace oversized files with stub when limit is set', async () => {
@@ -98,6 +103,41 @@ describe('OpenAPI extension', () => {
 
             // No warnings
             expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        it('writes the .openapi.json companion verbatim and never stubs it', async () => {
+            const {writeSpy} = await setup(1);
+
+            const companionCall = writeSpy.mock.calls.find((call) =>
+                call[0]?.toString().endsWith('petstore.openapi.json'),
+            );
+            expect(companionCall).toBeDefined();
+            expect(companionCall?.[1]).toBe('{"openapi":"3.0.0"}');
+            expect(companionCall?.[1]).not.toContain(STUB_MARKER);
+        });
+
+        it('writes the companion into the final output tree, not the temp input', async () => {
+            const {writeSpy, run} = await setup(0);
+
+            const companionCall = writeSpy.mock.calls.find((call) =>
+                call[0]?.toString().endsWith('petstore.openapi.json'),
+            );
+            expect(companionCall).toBeDefined();
+
+            // The companion must land in run.output and never in the temporary run.input
+            // (which is cleaned up after the build).
+            expect(companionCall?.[0]).toBe(join(run.output, 'api/petstore.openapi.json'));
+            expect(companionCall?.[0]?.toString().startsWith(run.input)).toBe(false);
+        });
+
+        it('registers the emitted companion on run, mapping it to the sibling index page', async () => {
+            const {run} = await setup(0);
+
+            // leadingPage is the sibling `index` (not derived from the companion file name).
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            expect((run as any).openapiCompanions).toEqual([
+                {leadingPage: 'api/index', companionPath: 'api/petstore.openapi.json'},
+            ]);
         });
     });
 });

--- a/src/extensions/openapi/index.ts
+++ b/src/extensions/openapi/index.ts
@@ -11,15 +11,57 @@ import {normalizePath} from '@diplodoc/cli/lib/utils';
 
 type Run = BaseRun & {
     toc?: TocService;
+    // The runtime instance is the build `Run`, which exposes the final output dir.
+    // `run.input` is a temporary working copy (cleaned after the build), so passthrough
+    // artifacts like the spec companion must be written straight to `run.output`.
+    output: AbsolutePath;
 };
 
 const EXTENSION = 'OpenapiIncluder';
 const INCLUDER = 'openapi';
 
+/** Suffix of the standalone OpenAPI spec companion files emitted by the includer. */
+const SPEC_COMPANION_SUFFIX = '.openapi.json';
+
+/** Entry recorded for each emitted companion so the build manifest can advertise it. */
+export type OpenapiCompanionEntry = {
+    /** Lang-relative path of the leading page (without extension), e.g. `ru/api/index`. */
+    leadingPage: string;
+    /**
+     * Lang-relative path of the companion file. The file name is derived from the source spec
+     * (`petstore.yaml` -> `petstore.openapi.json`), so it is not necessarily `index.openapi.json`,
+     * e.g. `ru/api/petstore.openapi.json`. The viewer must use this exact path.
+     */
+    companionPath: string;
+};
+
+/**
+ * Records an emitted companion on the shared `run` so the build-manifest feature can serialize
+ * the `leadingPage -> companionPath` mapping. Stored on `run` because the includer hook and the
+ * manifest hook run in the same build but live in different modules.
+ */
+function registerOpenapiCompanion(run: Run, tocPath: string, filePath: string) {
+    const companionPath = normalizePath(join(dirname(tocPath), filePath));
+    // The companion always sits next to the generated `index.md` leading page in the same
+    // directory; its file name is derived from the source spec, so the leading page cannot be
+    // recovered by stripping the suffix — it is the sibling `index`.
+    const leadingPage = normalizePath(join(dirname(companionPath), 'index'));
+
+    const store = run as Run & {openapiCompanions?: OpenapiCompanionEntry[]};
+    if (!Array.isArray(store.openapiCompanions)) {
+        store.openapiCompanions = [];
+    }
+
+    store.openapiCompanions.push({leadingPage, companionPath});
+}
+
 // TODO: move to openapi-extension on major
 export class Extension implements IExtension {
     apply(program: BaseProgram) {
-        getBaseHooks(program).BeforeAnyRun.tap(EXTENSION, (run: Run) => {
+        getBaseHooks(program).BeforeAnyRun.tap(EXTENSION, (baseRun) => {
+            // The runtime instance is the build `Run` (exposes `output`); the hook only
+            // statically guarantees `BaseRun`, so narrow it once here.
+            const run = baseRun as Run;
             getTocHooks(run.toc)
                 .Includer.for(INCLUDER)
                 .tapPromise(EXTENSION, async (rawtoc, options, from) => {
@@ -34,9 +76,21 @@ export class Extension implements IExtension {
                     const {toc, files} = await includer(run, options, from);
 
                     const root = join(run.input, dirname(options.path));
+                    // The companion is a passthrough artifact (not a TOC entry, not a media asset),
+                    // so the md/html pipelines never copy it from the temporary `run.input` to
+                    // `run.output`. Write it directly into the final output tree instead.
+                    const outputRoot = join(run.output, dirname(options.path));
                     const maxOpenapiIncludeSize =
                         (run.config as Hash)?.content?.maxOpenapiIncludeSize || 0;
                     for (const {path, content} of files) {
+                        // The standalone spec companion is gated (ai/outputFormat/size) inside the
+                        // includer; here we only persist it and register it in the build manifest.
+                        if (path.endsWith(SPEC_COMPANION_SUFFIX)) {
+                            await run.write(join(outputRoot, path) as AbsolutePath, content, true);
+                            registerOpenapiCompanion(run, options.path, path);
+                            continue;
+                        }
+
                         if (
                             maxOpenapiIncludeSize > 0 &&
                             Buffer.byteLength(content, 'utf-8') > maxOpenapiIncludeSize

--- a/tests/e2e/__snapshots__/regression.test.ts.snap
+++ b/tests/e2e/__snapshots__/regression.test.ts.snap
@@ -28,6 +28,7 @@ exports[`Regression > internal > filelist 1`] = `
   "merge/toc.yaml",
   "mermaid.md",
   "openapi/index.md",
+  "openapi/openapi-spec.openapi.json",
   "openapi/test-controller/getHiddenTest.md",
   "openapi/test-controller/getWithPayloadResponse.md",
   "openapi/test-controller/index.md",
@@ -66,6 +67,7 @@ exports[`Regression > internal > filelist 2`] = `
   "merge/toc.js",
   "mermaid.html",
   "openapi/index.html",
+  "openapi/openapi-spec.openapi.json",
   "openapi/test-controller/getHiddenTest.html",
   "openapi/test-controller/getWithPayloadResponse.html",
   "openapi/test-controller/index.html",
@@ -952,7 +954,9 @@ vcsPath: openapi/index.md
 {% endcut %}"
 `;
 
-exports[`Regression > internal 22`] = `
+exports[`Regression > internal 22`] = `"{"openapi":"3.0.1","info":{"title":"OpenAPI definition","version":"v0"},"servers":[{"url":"http://localhost:8080","description":"Generated server url"}],"paths":{"/test":{"get":{"tags":["test-controller"],"summary":"Simple get operation. тест новой верстки 3","description":"Defines a simple get operation with no inputs and a complex","operationId":"getWithPayloadResponse","responses":{"200":{"description":"200!!!!","content":{"application/json":{"schema":{"$ref":"#/components/schemas/RecurceTop"}}}}}}},"/hidden-test":{"get":{"tags":["test-controller"],"summary":"Test x-hidden attribute","description":"Test various x-hidden scenarios","operationId":"getHiddenTest","responses":{"200":{"description":"Response with hidden fields","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HiddenTestResponse"}}}}}}}},"components":{"schemas":{"RecurceTop":{"type":"object","properties":{"A":{"type":"string"}}},"HiddenTestResponse":{"type":"object","description":"Response object with various hidden field scenarios","properties":{"visibleField":{"type":"string","description":"This field should be visible"},"refToHiddenField":{"$ref":"#/components/schemas/HiddenField"},"refToHiddenObject":{"$ref":"#/components/schemas/HiddenObject"},"nestedObject":{"type":"object","description":"Object with hidden properties","properties":{"visibleNested":{"type":"string"},"refToHiddenInNested":{"$ref":"#/components/schemas/HiddenField"}}},"arrayWithHiddenItems":{"type":"array","description":"Array with hidden item schema","items":{"$ref":"#/components/schemas/HiddenField"}},"mixedVisibility":{"type":"object","properties":{"field1":{"type":"string"},"field2":{"$ref":"#/components/schemas/HiddenField"},"field3":{"type":"string"},"field5":{"type":"string"}}}}}}}}"`;
+
+exports[`Regression > internal 23`] = `
 "---
 metadata:
   - name: generator
@@ -1150,7 +1154,7 @@ _Example:_{.json-schema-reset .json-schema-example} \`example\`
 [*Deprecated]: No longer supported, please use an alternative and newer version."
 `;
 
-exports[`Regression > internal 23`] = `
+exports[`Regression > internal 24`] = `
 "---
 metadata:
   - name: generator
@@ -1232,7 +1236,7 @@ _Example:_{.json-schema-reset .json-schema-example} \`example\`
 [*Deprecated]: No longer supported, please use an alternative and newer version."
 `;
 
-exports[`Regression > internal 24`] = `
+exports[`Regression > internal 25`] = `
 "---
 metadata:
   - name: generator
@@ -1252,7 +1256,7 @@ vcsPath: openapi/test-controller/index.md
 "
 `;
 
-exports[`Regression > internal 25`] = `
+exports[`Regression > internal 26`] = `
 "files:
   - from: c.md
     to: d.md
@@ -1262,7 +1266,7 @@ common:
 "
 `;
 
-exports[`Regression > internal 26`] = `
+exports[`Regression > internal 27`] = `
 "---
 metadata:
   - name: generator
@@ -1279,7 +1283,7 @@ Item 1 text
 "
 `;
 
-exports[`Regression > internal 27`] = `
+exports[`Regression > internal 28`] = `
 "items:
   - name: Verbose root (index.yaml) will be transformed to index.html
     href: index.yaml
@@ -1344,13 +1348,13 @@ path: toc.yaml
 "
 `;
 
-exports[`Regression > internal 28`] = `
+exports[`Regression > internal 29`] = `
 "preprocess:
   mergeAutotitles: true
 "
 `;
 
-exports[`Regression > internal 29`] = `
+exports[`Regression > internal 30`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1378,7 +1382,7 @@ exports[`Regression > internal 29`] = `
 </html>"
 `;
 
-exports[`Regression > internal 30`] = `
+exports[`Regression > internal 31`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1406,7 +1410,7 @@ exports[`Regression > internal 30`] = `
 </html>"
 `;
 
-exports[`Regression > internal 31`] = `
+exports[`Regression > internal 32`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1434,7 +1438,7 @@ exports[`Regression > internal 31`] = `
 </html>"
 `;
 
-exports[`Regression > internal 32`] = `
+exports[`Regression > internal 33`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1462,7 +1466,7 @@ exports[`Regression > internal 32`] = `
 </html>"
 `;
 
-exports[`Regression > internal 33`] = `
+exports[`Regression > internal 34`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1490,7 +1494,7 @@ exports[`Regression > internal 33`] = `
 </html>"
 `;
 
-exports[`Regression > internal 34`] = `
+exports[`Regression > internal 35`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1518,7 +1522,7 @@ exports[`Regression > internal 34`] = `
 </html>"
 `;
 
-exports[`Regression > internal 35`] = `
+exports[`Regression > internal 36`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1546,7 +1550,7 @@ exports[`Regression > internal 35`] = `
 </html>"
 `;
 
-exports[`Regression > internal 36`] = `
+exports[`Regression > internal 37`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1574,7 +1578,7 @@ exports[`Regression > internal 36`] = `
 </html>"
 `;
 
-exports[`Regression > internal 37`] = `
+exports[`Regression > internal 38`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1602,7 +1606,7 @@ exports[`Regression > internal 37`] = `
 </html>"
 `;
 
-exports[`Regression > internal 38`] = `
+exports[`Regression > internal 39`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1630,7 +1634,7 @@ exports[`Regression > internal 38`] = `
 </html>"
 `;
 
-exports[`Regression > internal 39`] = `
+exports[`Regression > internal 40`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1658,7 +1662,7 @@ exports[`Regression > internal 39`] = `
 </html>"
 `;
 
-exports[`Regression > internal 40`] = `
+exports[`Regression > internal 41`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1686,7 +1690,7 @@ exports[`Regression > internal 40`] = `
 </html>"
 `;
 
-exports[`Regression > internal 41`] = `
+exports[`Regression > internal 42`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1714,7 +1718,7 @@ exports[`Regression > internal 41`] = `
 </html>"
 `;
 
-exports[`Regression > internal 42`] = `
+exports[`Regression > internal 43`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1742,7 +1746,7 @@ exports[`Regression > internal 42`] = `
 </html>"
 `;
 
-exports[`Regression > internal 43`] = `
+exports[`Regression > internal 44`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1770,7 +1774,7 @@ exports[`Regression > internal 43`] = `
 </html>"
 `;
 
-exports[`Regression > internal 44`] = `
+exports[`Regression > internal 45`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1798,7 +1802,7 @@ exports[`Regression > internal 44`] = `
 </html>"
 `;
 
-exports[`Regression > internal 45`] = `
+exports[`Regression > internal 46`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1826,7 +1830,7 @@ exports[`Regression > internal 45`] = `
 </html>"
 `;
 
-exports[`Regression > internal 46`] = `
+exports[`Regression > internal 47`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1854,9 +1858,9 @@ exports[`Regression > internal 46`] = `
 </html>"
 `;
 
-exports[`Regression > internal 47`] = `"window.__DATA__.data.toc = {"items":[{"name":"Use merged","href":"merge/merge.html","id":"UUID"},{"name":"Multitoc item","href":"1.html","id":"UUID"},{"name":"Merged item","href":"merge/merged.html","id":"UUID"}],"path":"merge/toc.yaml","id":"UUID"};"`;
+exports[`Regression > internal 48`] = `"window.__DATA__.data.toc = {"items":[{"name":"Use merged","href":"merge/merge.html","id":"UUID"},{"name":"Multitoc item","href":"1.html","id":"UUID"},{"name":"Merged item","href":"merge/merged.html","id":"UUID"}],"path":"merge/toc.yaml","id":"UUID"};"`;
 
-exports[`Regression > internal 48`] = `
+exports[`Regression > internal 49`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1884,7 +1888,7 @@ exports[`Regression > internal 48`] = `
 </html>"
 `;
 
-exports[`Regression > internal 49`] = `
+exports[`Regression > internal 50`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1912,7 +1916,9 @@ exports[`Regression > internal 49`] = `
 </html>"
 `;
 
-exports[`Regression > internal 50`] = `
+exports[`Regression > internal 51`] = `"{"openapi":"3.0.1","info":{"title":"OpenAPI definition","version":"v0"},"servers":[{"url":"http://localhost:8080","description":"Generated server url"}],"paths":{"/test":{"get":{"tags":["test-controller"],"summary":"Simple get operation. тест новой верстки 3","description":"Defines a simple get operation with no inputs and a complex","operationId":"getWithPayloadResponse","responses":{"200":{"description":"200!!!!","content":{"application/json":{"schema":{"$ref":"#/components/schemas/RecurceTop"}}}}}}},"/hidden-test":{"get":{"tags":["test-controller"],"summary":"Test x-hidden attribute","description":"Test various x-hidden scenarios","operationId":"getHiddenTest","responses":{"200":{"description":"Response with hidden fields","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HiddenTestResponse"}}}}}}}},"components":{"schemas":{"RecurceTop":{"type":"object","properties":{"A":{"type":"string"}}},"HiddenTestResponse":{"type":"object","description":"Response object with various hidden field scenarios","properties":{"visibleField":{"type":"string","description":"This field should be visible"},"refToHiddenField":{"$ref":"#/components/schemas/HiddenField"},"refToHiddenObject":{"$ref":"#/components/schemas/HiddenObject"},"nestedObject":{"type":"object","description":"Object with hidden properties","properties":{"visibleNested":{"type":"string"},"refToHiddenInNested":{"$ref":"#/components/schemas/HiddenField"}}},"arrayWithHiddenItems":{"type":"array","description":"Array with hidden item schema","items":{"$ref":"#/components/schemas/HiddenField"}},"mixedVisibility":{"type":"object","properties":{"field1":{"type":"string"},"field2":{"$ref":"#/components/schemas/HiddenField"},"field3":{"type":"string"},"field5":{"type":"string"}}}}}}}}"`;
+
+exports[`Regression > internal 52`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1940,7 +1946,7 @@ exports[`Regression > internal 50`] = `
 </html>"
 `;
 
-exports[`Regression > internal 51`] = `
+exports[`Regression > internal 53`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1968,7 +1974,7 @@ exports[`Regression > internal 51`] = `
 </html>"
 `;
 
-exports[`Regression > internal 52`] = `
+exports[`Regression > internal 54`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -1996,7 +2002,7 @@ exports[`Regression > internal 52`] = `
 </html>"
 `;
 
-exports[`Regression > internal 53`] = `
+exports[`Regression > internal 55`] = `
 "<!DOCTYPE html>
 <html lang="ru" dir="ltr">
     <head>
@@ -2024,4 +2030,4 @@ exports[`Regression > internal 53`] = `
 </html>"
 `;
 
-exports[`Regression > internal 54`] = `"window.__DATA__.data.toc = {"items":[{"name":"Verbose root (index.yaml) will be transformed to index.html","href":"index.html","id":"UUID"},{"name":"Root will be transformed to index.html","href":"index.html","id":"UUID"},{"name":"Md item with not_var syntax","href":"1.html","id":"UUID"},{"name":"Md item named without extension","href":"1.html","id":"UUID"},{"name":"Item with empty href","id":"UUID"},{"name":"Multitoc item","href":"merge/merged.html","id":"UUID"},{"name":"Fragments","href":"includes/fragments.html","id":"UUID"},{"name":"Included Item","href":"included-item.html","id":"UUID"},{"name":"Named include (items is Object here - this is not an error)","items":[{"name":"Item 1","href":"sub/folder/item-1.html","id":"UUID"}],"id":"UUID"},{"href":"mermaid.html","name":"Mermaid usage","id":"UUID"},{"name":"Latex usage","href":"latex.html","id":"UUID"},{"name":"Images","href":"images.html","id":"UUID"},{"name":"Autotitle","href":"autotitle.html","id":"UUID"},{"name":"includes","href":"includes.html","id":"UUID"},{"name":"Entry as include","href":"entry-as-include.html","id":"UUID"},{"name":"Includer of entry","href":"includer-of-entry.html","id":"UUID"},{"name":"generic","items":[{"name":"Note 1","href":"generic/1.html","id":"UUID"},{"name":"Note 1","href":"generic/2.html","id":"UUID"},{"name":"3","href":"generic/3.html","id":"UUID"},{"name":"Sub notes","items":[{"name":"Sub note 1","href":"generic/Sub notes/1.html","id":"UUID"},{"name":"Sub note 2","href":"generic/Sub notes/2.html","id":"UUID"}],"id":"UUID"}],"id":"UUID"},{"name":"openapi","items":[{"name":"Overview","href":"openapi/index.html","id":"UUID"},{"name":"test-controller","items":[{"name":"Overview","href":"openapi/test-controller/index.html","id":"UUID"},{"href":"openapi/test-controller/getWithPayloadResponse.html","name":"Simple get operation. тест новой верстки 3","id":"UUID"},{"href":"openapi/test-controller/getHiddenTest.html","name":"Test x-hidden attribute","id":"UUID"}],"id":"UUID"}],"id":"UUID"}],"path":"toc.yaml","id":"UUID"};"`;
+exports[`Regression > internal 56`] = `"window.__DATA__.data.toc = {"items":[{"name":"Verbose root (index.yaml) will be transformed to index.html","href":"index.html","id":"UUID"},{"name":"Root will be transformed to index.html","href":"index.html","id":"UUID"},{"name":"Md item with not_var syntax","href":"1.html","id":"UUID"},{"name":"Md item named without extension","href":"1.html","id":"UUID"},{"name":"Item with empty href","id":"UUID"},{"name":"Multitoc item","href":"merge/merged.html","id":"UUID"},{"name":"Fragments","href":"includes/fragments.html","id":"UUID"},{"name":"Included Item","href":"included-item.html","id":"UUID"},{"name":"Named include (items is Object here - this is not an error)","items":[{"name":"Item 1","href":"sub/folder/item-1.html","id":"UUID"}],"id":"UUID"},{"href":"mermaid.html","name":"Mermaid usage","id":"UUID"},{"name":"Latex usage","href":"latex.html","id":"UUID"},{"name":"Images","href":"images.html","id":"UUID"},{"name":"Autotitle","href":"autotitle.html","id":"UUID"},{"name":"includes","href":"includes.html","id":"UUID"},{"name":"Entry as include","href":"entry-as-include.html","id":"UUID"},{"name":"Includer of entry","href":"includer-of-entry.html","id":"UUID"},{"name":"generic","items":[{"name":"Note 1","href":"generic/1.html","id":"UUID"},{"name":"Note 1","href":"generic/2.html","id":"UUID"},{"name":"3","href":"generic/3.html","id":"UUID"},{"name":"Sub notes","items":[{"name":"Sub note 1","href":"generic/Sub notes/1.html","id":"UUID"},{"name":"Sub note 2","href":"generic/Sub notes/2.html","id":"UUID"}],"id":"UUID"}],"id":"UUID"},{"name":"openapi","items":[{"name":"Overview","href":"openapi/index.html","id":"UUID"},{"name":"test-controller","items":[{"name":"Overview","href":"openapi/test-controller/index.html","id":"UUID"},{"href":"openapi/test-controller/getWithPayloadResponse.html","name":"Simple get operation. тест новой верстки 3","id":"UUID"},{"href":"openapi/test-controller/getHiddenTest.html","name":"Test x-hidden attribute","id":"UUID"}],"id":"UUID"}],"id":"UUID"}],"path":"toc.yaml","id":"UUID"};"`;

--- a/tests/e2e/__snapshots__/translation.spec.ts.snap
+++ b/tests/e2e/__snapshots__/translation.spec.ts.snap
@@ -5,7 +5,6 @@ exports[`Translate command > build translated md files and remove no-translate d
   "index.md",
   "no-translate.md",
   "openapi/index.md",
-  "openapi/openapi-spec.openapi.json",
   "openapi/test-controller/getWithPayloadResponse.md",
   "openapi/test-controller/index.md",
   "toc.yaml"
@@ -189,9 +188,7 @@ vcsPath: openapi/index.md
 {% endcut %}"
 `;
 
-exports[`Translate command > build translated md files and remove no-translate directives 4`] = `"{"openapi":"3.0.1","info":{"title":"OpenAPI definition","version":"v0"},"servers":[{"url":"http://localhost:8080","description":"Generated server url"}],"paths":{"/test":{"get":{"tags":["test-controller"],"summary":"Simple get operation. тест новой верстки 3","description":"Defines a simple get :no-translate[skip this] operation with no inputs and a complex","operationId":"getWithPayloadResponse","responses":{"200":{"description":"200!!!!","content":{"application/json":{"schema":{"$ref":"#/components/schemas/RecurceTop"}}}}}}}},"components":{"schemas":{"RecurceTop":{"type":"object","properties":{"A":{"type":"string"}}}}}}"`;
-
-exports[`Translate command > build translated md files and remove no-translate directives 5`] = `
+exports[`Translate command > build translated md files and remove no-translate directives 4`] = `
 "---
 metadata:
   - name: generator
@@ -271,7 +268,7 @@ _Example:_{.json-schema-reset .json-schema-example} \`example\`
 [*Deprecated]: No longer supported, please use an alternative and newer version."
 `;
 
-exports[`Translate command > build translated md files and remove no-translate directives 6`] = `
+exports[`Translate command > build translated md files and remove no-translate directives 5`] = `
 "---
 metadata:
   - name: generator
@@ -288,7 +285,7 @@ vcsPath: openapi/test-controller/index.md
 "
 `;
 
-exports[`Translate command > build translated md files and remove no-translate directives 7`] = `
+exports[`Translate command > build translated md files and remove no-translate directives 6`] = `
 "title: Test123
 href: index.md
 items:
@@ -313,7 +310,6 @@ exports[`Translate command > build translated static files and remove no-transla
   "index.md",
   "no-translate.md",
   "openapi/index.md",
-  "openapi/openapi-spec.openapi.json",
   "openapi/test-controller/getWithPayloadResponse.md",
   "openapi/test-controller/index.md",
   "toc.yaml"
@@ -497,9 +493,7 @@ vcsPath: openapi/index.md
 {% endcut %}"
 `;
 
-exports[`Translate command > build translated static files and remove no-translate directives 4`] = `"{"openapi":"3.0.1","info":{"title":"OpenAPI definition","version":"v0"},"servers":[{"url":"http://localhost:8080","description":"Generated server url"}],"paths":{"/test":{"get":{"tags":["test-controller"],"summary":"Simple get operation. тест новой верстки 3","description":"Defines a simple get :no-translate[skip this] operation with no inputs and a complex","operationId":"getWithPayloadResponse","responses":{"200":{"description":"200!!!!","content":{"application/json":{"schema":{"$ref":"#/components/schemas/RecurceTop"}}}}}}}},"components":{"schemas":{"RecurceTop":{"type":"object","properties":{"A":{"type":"string"}}}}}}"`;
-
-exports[`Translate command > build translated static files and remove no-translate directives 5`] = `
+exports[`Translate command > build translated static files and remove no-translate directives 4`] = `
 "---
 metadata:
   - name: generator
@@ -579,7 +573,7 @@ _Example:_{.json-schema-reset .json-schema-example} \`example\`
 [*Deprecated]: No longer supported, please use an alternative and newer version."
 `;
 
-exports[`Translate command > build translated static files and remove no-translate directives 6`] = `
+exports[`Translate command > build translated static files and remove no-translate directives 5`] = `
 "---
 metadata:
   - name: generator
@@ -596,7 +590,7 @@ vcsPath: openapi/test-controller/index.md
 "
 `;
 
-exports[`Translate command > build translated static files and remove no-translate directives 7`] = `
+exports[`Translate command > build translated static files and remove no-translate directives 6`] = `
 "title: Test123
 href: index.md
 items:

--- a/tests/e2e/__snapshots__/translation.spec.ts.snap
+++ b/tests/e2e/__snapshots__/translation.spec.ts.snap
@@ -5,6 +5,7 @@ exports[`Translate command > build translated md files and remove no-translate d
   "index.md",
   "no-translate.md",
   "openapi/index.md",
+  "openapi/openapi-spec.openapi.json",
   "openapi/test-controller/getWithPayloadResponse.md",
   "openapi/test-controller/index.md",
   "toc.yaml"
@@ -188,7 +189,9 @@ vcsPath: openapi/index.md
 {% endcut %}"
 `;
 
-exports[`Translate command > build translated md files and remove no-translate directives 4`] = `
+exports[`Translate command > build translated md files and remove no-translate directives 4`] = `"{"openapi":"3.0.1","info":{"title":"OpenAPI definition","version":"v0"},"servers":[{"url":"http://localhost:8080","description":"Generated server url"}],"paths":{"/test":{"get":{"tags":["test-controller"],"summary":"Simple get operation. тест новой верстки 3","description":"Defines a simple get :no-translate[skip this] operation with no inputs and a complex","operationId":"getWithPayloadResponse","responses":{"200":{"description":"200!!!!","content":{"application/json":{"schema":{"$ref":"#/components/schemas/RecurceTop"}}}}}}}},"components":{"schemas":{"RecurceTop":{"type":"object","properties":{"A":{"type":"string"}}}}}}"`;
+
+exports[`Translate command > build translated md files and remove no-translate directives 5`] = `
 "---
 metadata:
   - name: generator
@@ -268,7 +271,7 @@ _Example:_{.json-schema-reset .json-schema-example} \`example\`
 [*Deprecated]: No longer supported, please use an alternative and newer version."
 `;
 
-exports[`Translate command > build translated md files and remove no-translate directives 5`] = `
+exports[`Translate command > build translated md files and remove no-translate directives 6`] = `
 "---
 metadata:
   - name: generator
@@ -285,7 +288,7 @@ vcsPath: openapi/test-controller/index.md
 "
 `;
 
-exports[`Translate command > build translated md files and remove no-translate directives 6`] = `
+exports[`Translate command > build translated md files and remove no-translate directives 7`] = `
 "title: Test123
 href: index.md
 items:
@@ -310,6 +313,7 @@ exports[`Translate command > build translated static files and remove no-transla
   "index.md",
   "no-translate.md",
   "openapi/index.md",
+  "openapi/openapi-spec.openapi.json",
   "openapi/test-controller/getWithPayloadResponse.md",
   "openapi/test-controller/index.md",
   "toc.yaml"
@@ -493,7 +497,9 @@ vcsPath: openapi/index.md
 {% endcut %}"
 `;
 
-exports[`Translate command > build translated static files and remove no-translate directives 4`] = `
+exports[`Translate command > build translated static files and remove no-translate directives 4`] = `"{"openapi":"3.0.1","info":{"title":"OpenAPI definition","version":"v0"},"servers":[{"url":"http://localhost:8080","description":"Generated server url"}],"paths":{"/test":{"get":{"tags":["test-controller"],"summary":"Simple get operation. тест новой верстки 3","description":"Defines a simple get :no-translate[skip this] operation with no inputs and a complex","operationId":"getWithPayloadResponse","responses":{"200":{"description":"200!!!!","content":{"application/json":{"schema":{"$ref":"#/components/schemas/RecurceTop"}}}}}}}},"components":{"schemas":{"RecurceTop":{"type":"object","properties":{"A":{"type":"string"}}}}}}"`;
+
+exports[`Translate command > build translated static files and remove no-translate directives 5`] = `
 "---
 metadata:
   - name: generator
@@ -573,7 +579,7 @@ _Example:_{.json-schema-reset .json-schema-example} \`example\`
 [*Deprecated]: No longer supported, please use an alternative and newer version."
 `;
 
-exports[`Translate command > build translated static files and remove no-translate directives 5`] = `
+exports[`Translate command > build translated static files and remove no-translate directives 6`] = `
 "---
 metadata:
   - name: generator
@@ -590,7 +596,7 @@ vcsPath: openapi/test-controller/index.md
 "
 `;
 
-exports[`Translate command > build translated static files and remove no-translate directives 6`] = `
+exports[`Translate command > build translated static files and remove no-translate directives 7`] = `
 "title: Test123
 href: index.md
 items:

--- a/tests/e2e/openapi-companion.spec.ts
+++ b/tests/e2e/openapi-companion.spec.ts
@@ -1,0 +1,213 @@
+import {existsSync, readFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+import {describe, expect, it} from 'vitest';
+
+import {TestAdapter, getTestPaths} from '../fixtures';
+
+/**
+ * These tests cover the CLI-side guarantees for the OpenAPI spec companion that are
+ * implemented in `packages/cli` (the openapi build wrapper + build-manifest feature):
+ *  - the standalone `*.openapi.json` file lands in the final output tree (md2md);
+ *  - its name is derived from the source spec (`petstore.yaml` -> `petstore.openapi.json`);
+ *  - it is recorded in the build manifest with the exact emitted path and the sibling
+ *    `index` leading page;
+ *  - emission does not depend on `--build-manifest`;
+ *  - for static md2html builds the companion hint is baked into the leading page `<body>`
+ *    as an HTML comment (the viewer does this at serve time for md2md, but md2html has no
+ *    viewer), gated by the companion actually being emitted.
+ *
+ * The companion *content* (filtering, x-hidden stripping, render-mode switching) is produced
+ * by `@diplodoc/openapi-extension` and is covered by that package's own unit tests.
+ */
+describe('OpenAPI spec companion (CLI build)', () => {
+    const COMPANION_PATH = 'api/petstore.openapi.json';
+    const LEADING_PAGE = 'api/index';
+
+    it('emits the .openapi.json companion into the md output tree', async () => {
+        const {inputPath, outputPath} = getTestPaths('mocks/openapi-companion');
+
+        await TestAdapter.testBuildPass(inputPath, outputPath, {
+            md2md: true,
+            md2html: false,
+        });
+
+        const companion = resolve(outputPath, COMPANION_PATH);
+        expect(existsSync(companion)).toBe(true);
+
+        // The companion sits next to the generated leading page.
+        expect(existsSync(resolve(outputPath, 'api/index.md'))).toBe(true);
+
+        const raw = readFileSync(companion, 'utf-8');
+
+        // Valid JSON describing the spec.
+        const json = JSON.parse(raw);
+        expect(json.openapi).toBeTruthy();
+        expect(json.paths).toBeTruthy();
+
+        // Minified: no pretty-print whitespace.
+        expect(raw).not.toContain('\n');
+        expect(raw).toBe(JSON.stringify(json));
+    });
+
+    it('emits the companion even without --build-manifest', async () => {
+        const {inputPath, outputPath} = getTestPaths('mocks/openapi-companion');
+
+        await TestAdapter.testBuildPass(inputPath, outputPath, {
+            md2md: true,
+            md2html: false,
+        });
+
+        expect(existsSync(resolve(outputPath, COMPANION_PATH))).toBe(true);
+        // Manifest is opt-in, so it must be absent here.
+        expect(existsSync(resolve(outputPath, 'yfm-build-manifest.json'))).toBe(false);
+    });
+
+    it('records the companion in the build manifest with the exact emitted path', async () => {
+        const {inputPath, outputPath} = getTestPaths('mocks/openapi-companion');
+
+        await TestAdapter.testBuildPass(inputPath, outputPath, {
+            md2md: true,
+            md2html: false,
+            args: '--build-manifest',
+        });
+
+        const manifest = JSON.parse(
+            readFileSync(resolve(outputPath, 'yfm-build-manifest.json'), 'utf-8'),
+        );
+
+        expect(Array.isArray(manifest.openapiCompanions)).toBe(true);
+
+        const entry = manifest.openapiCompanions.find(
+            (c: {companionPath: string}) => c.companionPath === COMPANION_PATH,
+        );
+        expect(entry).toBeDefined();
+        expect(entry.leadingPage).toBe(LEADING_PAGE);
+
+        // The path advertised by the manifest must resolve to a real file in the output.
+        expect(existsSync(resolve(outputPath, entry.companionPath))).toBe(true);
+    });
+
+    const COMMENT =
+        '<!-- json-схема со спецификацией доступна по ссылке: petstore.openapi.json -->';
+
+    it('bakes the companion comment into the static html body (md2html + ai opt-in)', async () => {
+        const {inputPath, outputPath} = getTestPaths('mocks/openapi-companion');
+
+        await TestAdapter.testBuildPass(inputPath, outputPath, {
+            md2md: false,
+            md2html: true,
+            // md2html emits the companion only when AI companions are explicitly enabled.
+            args: '--ai-openapi-companions',
+        });
+
+        expect(existsSync(resolve(outputPath, COMPANION_PATH))).toBe(true);
+
+        const html = readFileSync(resolve(outputPath, 'api/index.html'), 'utf-8');
+        expect(html).toContain(COMMENT);
+
+        // The comment must live inside <body>.
+        const body = html.slice(html.indexOf('<body'), html.indexOf('</body>'));
+        expect(body).toContain(COMMENT);
+    });
+
+    it('omits the companion and the comment for md2html without ai opt-in', async () => {
+        const {inputPath, outputPath} = getTestPaths('mocks/openapi-companion');
+
+        await TestAdapter.testBuildPass(inputPath, outputPath, {
+            md2md: false,
+            md2html: true,
+        });
+
+        expect(existsSync(resolve(outputPath, COMPANION_PATH))).toBe(false);
+
+        const html = readFileSync(resolve(outputPath, 'api/index.html'), 'utf-8');
+        expect(html).not.toContain('json-схема со спецификацией доступна по ссылке');
+    });
+});
+
+/**
+ * Covers the leading-page render-mode knobs introduced together with the companion:
+ *  - `leadingPage.spec.renderMode: inline | link` (toc);
+ *  - `--max-openapi-include-inline-size` auto-switching `inline -> link`;
+ *  - `ai.openapiCompanions: false` disabling companion emission.
+ *
+ * Assertions look at the generated leading page (`api/index.md`) and the presence of the
+ * companion file, which are the observable CLI-side outputs of these knobs.
+ */
+describe('OpenAPI leading page render modes & params (CLI build)', () => {
+    const COMPANION_PATH = 'api/petstore.openapi.json';
+    const INDEX_MD = 'api/index.md';
+    // Inline mode embeds the spec inside a `{% cut %}` block; link mode points to the companion.
+    const INLINE_MARKER = '{% cut "Open API" %}';
+    const LINK_MARKER = '[Open API specification](petstore.openapi.json)';
+
+    it('renderMode: inline (default) embeds the spec and still emits the companion', async () => {
+        const {inputPath, outputPath} = getTestPaths('mocks/openapi-companion');
+
+        await TestAdapter.testBuildPass(inputPath, outputPath, {md2md: true, md2html: false});
+
+        const index = readFileSync(resolve(outputPath, INDEX_MD), 'utf-8');
+        expect(index).toContain(INLINE_MARKER);
+        expect(index).not.toContain(LINK_MARKER);
+
+        expect(existsSync(resolve(outputPath, COMPANION_PATH))).toBe(true);
+    });
+
+    it('renderMode: link renders a link to the companion instead of inlining it', async () => {
+        const {inputPath, outputPath} = getTestPaths('mocks/openapi-companion-link');
+
+        await TestAdapter.testBuildPass(inputPath, outputPath, {md2md: true, md2html: false});
+
+        const index = readFileSync(resolve(outputPath, INDEX_MD), 'utf-8');
+        expect(index).toContain(LINK_MARKER);
+        expect(index).not.toContain(INLINE_MARKER);
+
+        expect(existsSync(resolve(outputPath, COMPANION_PATH))).toBe(true);
+    });
+
+    it('--max-openapi-include-inline-size auto-switches inline -> link for large specs', async () => {
+        const {inputPath, outputPath} = getTestPaths('mocks/openapi-companion');
+
+        await TestAdapter.testBuildPass(inputPath, outputPath, {
+            md2md: true,
+            md2html: false,
+            // 1 byte: any real spec exceeds it, forcing the link form.
+            args: '--max-openapi-include-inline-size 1',
+        });
+
+        const index = readFileSync(resolve(outputPath, INDEX_MD), 'utf-8');
+        expect(index).toContain(LINK_MARKER);
+        expect(index).not.toContain(INLINE_MARKER);
+
+        expect(existsSync(resolve(outputPath, COMPANION_PATH))).toBe(true);
+    });
+
+    it('--max-openapi-include-inline-size 0 always renders the spec as a link', async () => {
+        const {inputPath, outputPath} = getTestPaths('mocks/openapi-companion');
+
+        await TestAdapter.testBuildPass(inputPath, outputPath, {
+            md2md: true,
+            md2html: false,
+            args: '--max-openapi-include-inline-size 0',
+        });
+
+        const index = readFileSync(resolve(outputPath, INDEX_MD), 'utf-8');
+        expect(index).toContain(LINK_MARKER);
+        expect(index).not.toContain(INLINE_MARKER);
+
+        expect(existsSync(resolve(outputPath, COMPANION_PATH))).toBe(true);
+    });
+
+    it('ai.openapiCompanions: false disables the companion file (md2md)', async () => {
+        const {inputPath, outputPath} = getTestPaths('mocks/openapi-companion-disabled');
+
+        await TestAdapter.testBuildPass(inputPath, outputPath, {md2md: true, md2html: false});
+
+        expect(existsSync(resolve(outputPath, COMPANION_PATH))).toBe(false);
+
+        // With no companion to link to, the leading page falls back to inlining the spec.
+        const index = readFileSync(resolve(outputPath, INDEX_MD), 'utf-8');
+        expect(index).toContain(INLINE_MARKER);
+        expect(index).not.toContain(LINK_MARKER);
+    });
+});

--- a/tests/e2e/translation.spec.ts
+++ b/tests/e2e/translation.spec.ts
@@ -44,7 +44,13 @@ const buildFilesYamlTestTemplate = (
         const {inputPath, outputPath} = getTestPaths(testRootPath);
         const {md2md, md2html} = buildProps;
 
-        await TestAdapter.testBuildPass(inputPath, outputPath, {md2html, md2md});
+        // Disable OpenAPI spec companions: the mock ships an openapi spec, and emitting the
+        // `*.openapi.json` companion would change these translation snapshots.
+        await TestAdapter.testBuildPass(inputPath, outputPath, {
+            md2html,
+            md2md,
+            args: '--no-ai-openapi-companions',
+        });
 
         await compareDirectories(outputPath);
     });

--- a/tests/mocks/openapi-companion-disabled/input/.yfm
+++ b/tests/mocks/openapi-companion-disabled/input/.yfm
@@ -1,0 +1,2 @@
+ai:
+  openapiCompanions: false

--- a/tests/mocks/openapi-companion-disabled/input/petstore.yaml
+++ b/tests/mocks/openapi-companion-disabled/input/petstore.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: Pet Store
+  version: v1
+servers:
+  - url: http://localhost:8080
+paths:
+  /pets:
+    get:
+      tags:
+        - pets
+      summary: List pets
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string

--- a/tests/mocks/openapi-companion-disabled/input/toc.yaml
+++ b/tests/mocks/openapi-companion-disabled/input/toc.yaml
@@ -1,0 +1,9 @@
+title: OpenAPI Companion Disabled Test
+items:
+  - name: API
+    include:
+      path: api
+      includers:
+        - name: openapi
+          input: petstore.yaml
+      mode: link

--- a/tests/mocks/openapi-companion-link/input/petstore.yaml
+++ b/tests/mocks/openapi-companion-link/input/petstore.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: Pet Store
+  version: v1
+servers:
+  - url: http://localhost:8080
+paths:
+  /pets:
+    get:
+      tags:
+        - pets
+      summary: List pets
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string

--- a/tests/mocks/openapi-companion-link/input/toc.yaml
+++ b/tests/mocks/openapi-companion-link/input/toc.yaml
@@ -1,0 +1,12 @@
+title: OpenAPI Companion Link Test
+items:
+  - name: API
+    include:
+      path: api
+      includers:
+        - name: openapi
+          input: petstore.yaml
+          leadingPage:
+            spec:
+              renderMode: 'link'
+      mode: link

--- a/tests/mocks/openapi-companion/input/petstore.yaml
+++ b/tests/mocks/openapi-companion/input/petstore.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: Pet Store
+  version: v1
+servers:
+  - url: http://localhost:8080
+paths:
+  /pets:
+    get:
+      tags:
+        - pets
+      summary: List pets
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string

--- a/tests/mocks/openapi-companion/input/toc.yaml
+++ b/tests/mocks/openapi-companion/input/toc.yaml
@@ -1,0 +1,9 @@
+title: OpenAPI Companion Test
+items:
+  - name: API
+    include:
+      path: api
+      includers:
+        - name: openapi
+          input: petstore.yaml
+      mode: link


### PR DESCRIPTION
- config section `ai.openapiCompanions` (`true | 'md' | false`, default `'md'`);
- CLI flag `--ai-openapi-companions` (boolean override);
- option `--max-openapi-include-inline-size` (default 100K, max 1M);
- yfm-schema: section `ai` + `content.maxOpenapiIncludeInlineSize` (+ documented
  `content.maxOpenapiIncludeSize`).
- CLI-wrapper openapi writes `*.openapi.json` as is (without stub-logic) and registers the entry;
- build-manifest adds an array of `openapiCompanions` (`{leadingPage, companionPath}`),
  dedup + deterministic sorting;
- HTML-comment with a link to `.openapi.json` for **static** `md2html`-build:
  the viewer adds it when returning only for md2md, but the `md2html` viewer doesn't have it, so the comment
  babbles directly in the `<body>` of a ready-made html-rendering (HTML comments from markdown
 are cut out by the transformation). It is gated by the fact of companion emission (depends on `renderMode`
 and `ai.openapiCompanions`).