### PR TITLE
fix(build-content-map): stabilize content hash for inlined SVG ids

### DIFF
--- a/src/commands/build/features/build-content-map/index.spec.ts
+++ b/src/commands/build/features/build-content-map/index.spec.ts
@@ -399,6 +399,60 @@ describe('BuildContentMap', () => {
         });
     });
 
+    describe('normalizeForHash inline svg ids', () => {
+        // The inline-SVG transform (md2md) prefixes every id inside an inlined
+        // SVG with `svg-<random>__` (SVGO prefixIds, prefix from the build's
+        // id-generator). With the default `random` strategy that prefix flips
+        // on every build of an unchanged source, so two builds of the same page
+        // must still hash identically once the volatile prefix is canonicalized.
+        it('canonicalizes volatile random svg id prefixes so the hash is stable', () => {
+            const buildA = Buffer.from(
+                '# Page\n\nx <svg><clipPath id="svg-1gkkvptx__clip0_1"><rect/></clipPath>' +
+                    '<path clip-path="url(#svg-1gkkvptx__clip0_1)" fill="url(#svg-1gkkvptx__p0)"/></svg>\n',
+            );
+            const buildB = Buffer.from(
+                '# Page\n\nx <svg><clipPath id="svg-0weejvx8__clip0_1"><rect/></clipPath>' +
+                    '<path clip-path="url(#svg-0weejvx8__clip0_1)" fill="url(#svg-0weejvx8__p0)"/></svg>\n',
+            );
+            expect(hashContent(normalizeForHash(buildA, 'page.md' as NormalizedPath))).toBe(
+                hashContent(normalizeForHash(buildB, 'page.md' as NormalizedPath)),
+            );
+        });
+
+        it('canonicalizes svg ids even when the file has no frontmatter', () => {
+            const a = Buffer.from('<svg><path id="svg-11111111__x"/></svg>');
+            const b = Buffer.from('<svg><path id="svg-22222222__x"/></svg>');
+            expect(hashContent(normalizeForHash(a, 'page.md' as NormalizedPath))).toBe(
+                hashContent(normalizeForHash(b, 'page.md' as NormalizedPath)),
+            );
+        });
+
+        it('canonicalizes svg ids alongside volatile frontmatter stripping', () => {
+            const a = Buffer.from(
+                '---\ntitle: Foo\nupdatedAt: 2026-05-26T10:00:00Z\n---\n\n<svg><path id="svg-aaaaaaaa__x"/></svg>\n',
+            );
+            const b = Buffer.from(
+                '---\ntitle: Foo\nupdatedAt: 2030-01-01T00:00:00Z\n---\n\n<svg><path id="svg-bbbbbbbb__x"/></svg>\n',
+            );
+            expect(hashContent(normalizeForHash(a, 'page.md' as NormalizedPath))).toBe(
+                hashContent(normalizeForHash(b, 'page.md' as NormalizedPath)),
+            );
+        });
+
+        it('keeps the hash sensitive to real svg content changes', () => {
+            const a = Buffer.from('# P\n\n<svg><path id="svg-aaaaaaaa__p" d="M1 2"/></svg>\n');
+            const b = Buffer.from('# P\n\n<svg><path id="svg-bbbbbbbb__p" d="M9 9"/></svg>\n');
+            expect(hashContent(normalizeForHash(a, 'page.md' as NormalizedPath))).not.toBe(
+                hashContent(normalizeForHash(b, 'page.md' as NormalizedPath)),
+            );
+        });
+
+        it('leaves markdown without svg ids byte-identical', () => {
+            const plain = Buffer.from('# No svg here\n\njust text\n');
+            expect(normalizeForHash(plain, 'page.md' as NormalizedPath)).toEqual(plain);
+        });
+    });
+
     describe('snapshot', () => {
         it('emits a stable JSON shape for a typical md build', async () => {
             const build = new Build();

--- a/src/commands/build/features/build-content-map/index.ts
+++ b/src/commands/build/features/build-content-map/index.ts
@@ -234,8 +234,36 @@ function hasVolatile(obj: Record<string, unknown>): boolean {
     return false;
 }
 
+// The inline-SVG transform (md2md, see output-md/plugins/merge-svg.ts) inlines
+// SVG assets and runs them through SVGO `prefixIds`, which rewrites every id
+// inside the SVG to `<prefix>__<id>`. The prefix comes from the build's
+// id-generator; with the default `random` strategy it is `svg-<8 base36 chars>`
+// derived from `Math.random()`, so it differs on every build of an unchanged
+// source. That volatile prefix would flip the page's content-hash on each
+// rebuild, producing false-positive diffs for consumers (change
+// notifications, search reindex). Canonicalize it to a fixed marker so the
+// hash reflects the SVG's content, not its per-build ids. The same prefix
+// appears in both `id="…"` definitions and their `url(#…)` / href references,
+// and the global replace rewrites all of them identically, so they stay
+// internally consistent. Real SVG content (paths, dimensions, the original
+// id stems after `__`) is preserved, so genuine changes still move the hash.
+//
+// Coupled to transform's prefix shape (`@diplodoc/transform`
+// plugins/images `replaceSvgContent` → SVGO `prefixIds` with prefix
+// `generateID('svg')`). If transform changes that shape this stops matching;
+// the `inline svg ids` tests pin the current shape.
+const VOLATILE_SVG_ID_PREFIX_RE = /svg-[0-9a-z]+__/g;
+
+function canonicalizeSvgIds(text: string): string {
+    return text.replace(VOLATILE_SVG_ID_PREFIX_RE, 'svg__');
+}
+
 function normalizeMarkdown(content: Buffer): Buffer {
-    const text = content.toString('utf8');
+    // Canonicalize volatile inline-SVG ids before any frontmatter handling so
+    // every return path below hashes the de-noised body. When the source has
+    // no inlined SVG this is a no-op and `text === content`'s utf8 view, so
+    // files without SVG ids keep their `hash == sha256(file bytes)` property.
+    const text = canonicalizeSvgIds(content.toString('utf8'));
 
     let fm: unknown;
     let body: string;
@@ -246,25 +274,25 @@ function normalizeMarkdown(content: Buffer): Buffer {
         body = stripped;
         rawFrontmatter = raw;
     } catch {
-        // Malformed YAML inside the fences — hash the raw bytes.
-        return content;
+        // Malformed YAML inside the fences — hash the SVG-canonicalized bytes.
+        return Buffer.from(text, 'utf8');
     }
 
     // `extractFrontMatter` returns an empty string for `rawFrontmatter`
     // when the file has no frontmatter fences at all (or when fences are
-    // unbalanced and don't match its regex). In both cases there's
-    // nothing to normalize — return raw bytes.
+    // unbalanced and don't match its regex). In both cases there's no
+    // frontmatter to strip — hash the SVG-canonicalized bytes.
     if (!rawFrontmatter) {
-        return content;
+        return Buffer.from(text, 'utf8');
     }
 
     if (!fm || typeof fm !== 'object' || Array.isArray(fm)) {
-        return content;
+        return Buffer.from(text, 'utf8');
     }
     const fmObj = fm as Record<string, unknown>;
 
     if (!hasVolatile(fmObj)) {
-        return content;
+        return Buffer.from(text, 'utf8');
     }
 
     const strippedFm = stripVolatile(fmObj);


### PR DESCRIPTION
## Problem

The documentation changes digest reports pages as “changed” even though their Markdown source did not change between revisions. In a real run, 5 out of 6 pages were false positives.

The diff is built from the `yfm-build-content.json` artifact via the `build-content-map` feature: a page is added to `changed` if its content hash differs between revisions.

## Cause

In md2md, inline SVG is processed through SVGO `prefixIds`, which rewrites all IDs inside the SVG to `svg-<random>__<id>`. With the default `--id-generator random` strategy, the prefix is generated using `Math.random()` and changes on every build, even when the source is unchanged. As a result, the page content hash differs on every rebuild → false positives in the diff.

This is the only volatile pattern in md2md output: terms, tabs, and inline code remain in Markdown syntax and do not receive IDs at this stage.

## Solution

I’m extending the existing `normalizeForHash` logic — the same place where `updatedAt`, `contributors`, and `metadata.generator` are stripped. Before hashing, the volatile prefix `svg-<token>__` is canonicalized to `svg__`. This covers both `id="…"` and `url(#…)`/`href` references: everything is rewritten consistently, so links remain valid. The actual SVG content — paths, dimensions, and the original IDs after `__` — is preserved, so real changes still affect the hash.

This is a surgical fix: it stabilizes only the hash in `yfm-build-content.json` and **does not change the build output or defaults**.

## Verification

- Building the same revision twice with the default `random` strategy: content hashes for all unchanged pages are **identical**, while the raw output bytes still differ because the IDs remain random. Pages with inline SVG included via `include` are stable as well.
- Sensitivity to real SVG edits is preserved.
- Unit tests, including 5 new canonicalization tests, and the `build-content-map` e2e test are green.
- Build time impact: `.replace()` is about 4× cheaper than SHA-256 on the same content (~10 GB/s); on documentation with 1000 pages, it adds ~0.8 ms.