### PR TITLE
fix: fixed pc md images

### DIFF
--- a/src/commands/build/features/pdf-page/index.ts
+++ b/src/commands/build/features/pdf-page/index.ts
@@ -5,6 +5,7 @@ import type {Command} from '~/core/config';
 import type {PageContent} from '@diplodoc/page-constructor-extension';
 
 import {dirname, join} from 'node:path';
+import parse from 'node-html-parser';
 import {createServerPageConstructorContent} from '@diplodoc/page-constructor-extension/renderer';
 
 import {getHooks as getBuildHooks, getEntryHooks} from '~/commands/build';
@@ -21,6 +22,7 @@ import {
     getPdfUrl,
     isEntryHidden,
     joinPdfPageResults,
+    rebaseImgSrc,
     replacePCNestedLinks,
     ssrPageConstructorBlocks,
 } from './utils';
@@ -132,10 +134,12 @@ export class PdfPage {
                     'pdf',
                     async (content, _meta, file) => {
                         const html = createServerPageConstructorContent(content as PageContent);
+                        const root = parse(html);
+                        rebaseImgSrc(root, dirname(file));
 
                         results[file] = {
                             path: file,
-                            content: replacePCNestedLinks(html),
+                            content: replacePCNestedLinks(root.toString()),
                             title: '',
                         };
                     },

--- a/src/commands/build/features/pdf-page/utils.ts
+++ b/src/commands/build/features/pdf-page/utils.ts
@@ -331,7 +331,7 @@ export function ssrPageConstructorBlocks(html: string): string {
             const content = JSON.parse(decodeURIComponent(encoded)) as PageContent;
             const rendered = createServerPageConstructorContent(content);
 
-            node.replaceWith(rendered);
+            node.replaceWith(replacePCNestedLinks(rendered));
         } catch {}
     }
 


### PR DESCRIPTION
Previously, we rendered page-constructor blocks from regular Markdown pages using `createServerPageConstructorContent`, but didn't call `replacePCNestedLinks` on the result. This left nested `<a>` tags.

Chromium doesn't allow nested `<a>` tags and automatically breaks external links when encountering internal ones.