### PR TITLE
fix: yaml compose format fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,8 @@
         "postcss": "^8.5.15",
         "tapable": "2.2.1",
         "threads": "1.7.0",
-        "ts-dedent": "2.2.0"
+        "ts-dedent": "2.2.0",
+        "yaml": "^2.8.0"
       },
       "bin": {
         "docs": "build/index.js",
@@ -18625,7 +18626,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "glob": "^10.4.5",
     "highlight.js": "^11.10.0",
     "js-yaml": "4.1.0",
+    "yaml": "^2.8.0",
     "katex": "0.16.9",
     "lodash": "4.17.21",
     "markdown-it": "^13.0.2",

--- a/src/commands/translate/utils/fs.ts
+++ b/src/commands/translate/utils/fs.ts
@@ -2,7 +2,8 @@ import type {AjvOptions, JSONObject, LinkedJSONObject} from '@diplodoc/translati
 
 import {dirname, resolve} from 'node:path';
 import {mkdir, readFile, writeFile} from 'node:fs/promises';
-import {dump, load} from 'js-yaml';
+import {load} from 'js-yaml';
+import {stringify} from 'yaml';
 import {linkRefs, unlinkRefs} from '@diplodoc/translation';
 import {
     leadingSchemaJson,
@@ -43,7 +44,20 @@ function stringifyFile(content: JSONObject | string, path: string): string {
 
     switch (ext(path)) {
         case 'yaml':
-            return dump(content, {noRefs: true, lineWidth: -1});
+            return stringify(
+                content as Record<string, unknown>,
+                (_key, value) => {
+                    if (typeof value === 'string') {
+                        return value.replace(/[ \t]+$/, '');
+                    }
+                    return value;
+                },
+                {
+                    aliasDuplicateObjects: false,
+                    lineWidth: 0,
+                    singleQuote: true,
+                },
+            );
         case 'json':
             return JSON.stringify(content);
         default:

--- a/tests/e2e/__snapshots__/translation.spec.ts.snap
+++ b/tests/e2e/__snapshots__/translation.spec.ts.snap
@@ -698,7 +698,7 @@ exports[`Translate command > compose yaml files with no extra spaces > filelist 
 
 exports[`Translate command > compose yaml files with no extra spaces 1`] = `
 "meta:
-  title: "Adfox/_— Справка"
+  title: Adfox — Справка
   description: 'Справка по работе с сервисом Adfox: управление инвентарем, рекламой, монетизация и аналитика.'
 fullScreen: true
 blocks:
@@ -711,6 +711,22 @@ blocks:
           url: https://yandex.ru/support/?lang=ru
         - text: Adfox
           url: https://yandex.ru/support/adfox/ru/?lang=ru
+  - type: tabs-block
+    title:
+      text: ''
+    items:
+      - tabName: Varioqub Unity
+        title: Плагин Varioqub Unity
+        text: |
+          [Varioqub Unity](https://github.com/appmetrica/varioqub-unity-plugin) —  это плагин для игровой платформы [Unity3d](http://docs.unity3d.com/). Он включает поддержку Varioqub SDK для Android и iOS.
+
+          #### История версий
+
+          ##### Версия 0.1.0
+
+          **10.07.2024**
+
+          - первый релиз.
 "
 `;
 
@@ -1434,11 +1450,10 @@ exports[`Translate command > extract yaml scheme files 3`] = `
     textWidth: l
     textContent:
       title: '%%%0%%%'
-      text: |2-
+      text: |2
          %%%1%%%
          - %%%2%%%
          - %%%3%%%
-         
   - type: card-layout-block
     colSizes:
       all: 12

--- a/tests/mocks/translation/yaml-space-format/input/index.yaml.skl
+++ b/tests/mocks/translation/yaml-space-format/input/index.yaml.skl
@@ -12,3 +12,19 @@ blocks:
           url: https://yandex.ru/support/?lang=ru
         - text: '%%%5%%%'
           url: https://yandex.ru/support/adfox/ru/?lang=ru
+  - type: tabs-block
+    title:
+      text: ''
+    items:
+      - tabName: Varioqub Unity
+        title: '%%%6%%%'
+        text: |
+          %%%7%%% %%%8%%%
+
+          #### %%%9%%%
+
+          ##### %%%10%%%
+
+          %%%11%%%
+
+          - %%%12%%%

--- a/tests/mocks/translation/yaml-space-format/input/index.yaml.xliff
+++ b/tests/mocks/translation/yaml-space-format/input/index.yaml.xliff
@@ -31,6 +31,34 @@
         <source xml:space="preserve">Adfox</source>
         <target xml:space="preserve">Adfox</target>
       </trans-unit>
+      <trans-unit id="6">
+        <source xml:space="preserve">Плагин Varioqub Unity</source>
+        <target xml:space="preserve">Плагин Varioqub Unity</target>
+      </trans-unit>
+      <trans-unit id="7">
+        <source xml:space="preserve"><g ctype="link" equiv-text="[{{text}}](https://github.com/appmetrica/varioqub-unity-plugin)" id="g-5" x-begin="[" x-end="](https://github.com/appmetrica/varioqub-unity-plugin)">Varioqub Unity</g> —  это плагин для игровой платформы <g ctype="link" equiv-text="[{{text}}](http://docs.unity3d.com/)" id="g-6" x-begin="[" x-end="](http://docs.unity3d.com/)">Unity3d</g>.</source>
+        <target xml:space="preserve"><g ctype="link" equiv-text="[{{text}}](https://github.com/appmetrica/varioqub-unity-plugin)" id="g-5" x-begin="[" x-end="](https://github.com/appmetrica/varioqub-unity-plugin)">Varioqub Unity</g> —  это плагин для игровой платформы <g ctype="link" equiv-text="[{{text}}](http://docs.unity3d.com/)" id="g-6" x-begin="[" x-end="](http://docs.unity3d.com/)">Unity3d</g>.</target>
+      </trans-unit>
+      <trans-unit id="8">
+        <source xml:space="preserve">Он включает поддержку Varioqub SDK для Android и iOS.</source>
+        <target xml:space="preserve">Он включает поддержку Varioqub SDK для Android и iOS.</target>
+      </trans-unit>
+      <trans-unit id="9">
+        <source xml:space="preserve">История версий</source>
+        <target xml:space="preserve">История версий</target>
+      </trans-unit>
+      <trans-unit id="10">
+        <source xml:space="preserve">Версия 0.1.0</source>
+        <target xml:space="preserve">Версия 0.1.0</target>
+      </trans-unit>
+      <trans-unit id="11">
+        <source xml:space="preserve"><g ctype="bold" equiv-text="**{{text}}**" id="g-7" x-begin="**" x-end="**">10.07.2024</g></source>
+        <target xml:space="preserve"><g ctype="bold" equiv-text="**{{text}}**" id="g-7" x-begin="**" x-end="**">10.07.2024</g></target>
+      </trans-unit>
+      <trans-unit id="12">
+        <source xml:space="preserve">первый релиз.</source>
+        <target xml:space="preserve">первый релиз.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
#### Use yaml stringify instead of js-yaml dump

The main reason is that js-yaml dump strips some unicode symbols, trailing space in strict mode and thus we have differently formated text on compose output procedure.

Yaml stringify method acts differently and may save initial formatting, except one edge case related to trailing space in multiline string
