### PR TITLE
fix: edit meta keywords parse

### DIFF
--- a/src/commands/build/services/entry/EntryService.ts
+++ b/src/commands/build/services/entry/EntryService.ts
@@ -184,7 +184,13 @@ export class EntryService {
         metadata.filter(isPublicMeta).map(template.addMeta);
 
         Object.entries(restYamlConfigMeta)
-            .map(([name, content]) => ({name, content}))
+            .map(([name, content]) => {
+                if (name === 'keywords' && Array.isArray(content)) {
+                    const cleanKeywords = this.cleanKeywords(content);
+                    return {name, content: cleanKeywords};
+                }
+                return {name, content};
+            })
             .filter(isPublicMeta)
             .map(template.addMeta);
 
@@ -292,5 +298,19 @@ export class EntryService {
         } else {
             return this.run.markdown;
         }
+    }
+
+    private cleanKeywords(content: any[]): string {
+        return content
+            .map((k: any) => {
+                const str = typeof k === 'object' && k && 'keyword' in k ? k.keyword : k;
+
+                return str
+                    .replace(/\{\{[^}]*\}\}/g, '')
+                    .replace(/\s+/g, ' ')
+                    .trim();
+            })
+            .filter((str: string) => str.length > 2)
+            .join(', ');
     }
 }

--- a/src/commands/build/services/entry/index.spec.ts
+++ b/src/commands/build/services/entry/index.spec.ts
@@ -1,0 +1,74 @@
+import {describe, expect, it} from 'vitest';
+
+import {EntryService} from './EntryService';
+
+const cleanKeywords = (content: any[]) => {
+    return (EntryService.prototype as any).cleanKeywords(content);
+};
+
+const createMockService = (relationsMock: any) => {
+    const service = Object.create(EntryService.prototype);
+    service.relations = {
+        hasNode: (path: string) => Boolean(relationsMock[path]),
+        getNodeData: (path: string) => relationsMock[path] || {},
+    };
+    return service;
+};
+
+describe('EntryService', () => {
+    describe('cleanKeywords', () => {
+        it('keeps and formats valid plain string items', () => {
+            expect(cleanKeywords(['foo', 'bar'])).toEqual('foo, bar');
+        });
+
+        it('extracts target values from object keywords mapping cleanly', () => {
+            expect(cleanKeywords([{keyword: 'Yandex'}, {keyword: 'taxi'}])).toEqual('Yandex, taxi');
+            expect(cleanKeywords(['plain', {keyword: 'wrapped'}])).toEqual('plain, wrapped');
+        });
+
+        it('strips away layout template brackets and duplicate middle spaces', () => {
+            expect(cleanKeywords([{keyword: '  wrapped   spacing '}, 'normal'])).toEqual(
+                'wrapped spacing, normal',
+            );
+            expect(
+                cleanKeywords([{keyword: 'Номер телефона {{yandex}}'}, 'контакт {{unknown-var}}']),
+            ).toEqual('Номер телефона, контакт');
+        });
+
+        it('filters out short keywords falling below length threshold', () => {
+            expect(cleanKeywords(['ok', 'sh', 'longer-word'])).toEqual('longer-word');
+        });
+    });
+
+    describe('isSource / isResource graph filters', () => {
+        const mockGraph = {
+            'docs/file.md': {type: 'source'},
+            'assets/image.png': {type: 'resource'},
+            'config/data.yaml': {type: 'entry'},
+        };
+
+        it('returns false for both if path is missing from graph nodes', () => {
+            const service = createMockService(mockGraph);
+            expect(service.isSource('docs/unknown.md')).toEqual(false);
+            expect(service.isResource('docs/unknown.md')).toEqual(false);
+        });
+
+        it('correctly maps and evaluates type: source paths', () => {
+            const service = createMockService(mockGraph);
+            expect(service.isSource('docs/file.md')).toEqual(true);
+            expect(service.isResource('docs/file.md')).toEqual(false);
+        });
+
+        it('correctly maps and evaluates type: resource paths', () => {
+            const service = createMockService(mockGraph);
+            expect(service.isSource('assets/image.png')).toEqual(false);
+            expect(service.isResource('assets/image.png')).toEqual(true);
+        });
+
+        it('returns false for other internal node types like entry', () => {
+            const service = createMockService(mockGraph);
+            expect(service.isSource('config/data.yaml')).toEqual(false);
+            expect(service.isResource('config/data.yaml')).toEqual(false);
+        });
+    });
+});

--- a/tests/e2e/__snapshots__/files.spec.ts.snap
+++ b/tests/e2e/__snapshots__/files.spec.ts.snap
@@ -141,7 +141,7 @@ exports[`Static files from _assets directory > Download link should be enabled 5
         <base href="./" />
         <title>Test123</title>
         <meta name="generator" content="Diplodoc Platform vDIPLODOC-VERSION">
-        <meta name="keywords" content="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]">
+        <meta name="keywords" content="Сервис, Сервис для бизнес аналитики, BI аналитика, Визуализация данных в, Как подключиться к источнику данных, бизнес-метрики в, Аналитика">
         <style type="text/css">html, body {min-height:100vh; height:100vh;}</style>
     </head>
     <body class="g-root g-root_theme_light">

--- a/tests/e2e/__snapshots__/metadata-parse-keywords.spec.ts.snap
+++ b/tests/e2e/__snapshots__/metadata-parse-keywords.spec.ts.snap
@@ -1,0 +1,40 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Parse and render HTML meta keywords > md2html with structured keywords > filelist 1`] = `
+"[
+  "index.html",
+  "toc.js"
+]"
+`;
+
+exports[`Parse and render HTML meta keywords > md2html with structured keywords 1`] = `
+"<!DOCTYPE html>
+<html lang="ru" dir="ltr">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <base href="./" />
+        <title>Общая поддержка Яндекса</title>
+        <meta name="generator" content="Diplodoc Platform vDIPLODOC-VERSION">
+        <meta name="description" content="Поддержка для пользователей, которые столкнулись с проблемой или у которых возникли вопросы по сервисам Яндекса.">
+        <meta name="keywords" content="Номер телефона Yandex, Яндекс контакты, Телефон яндекс такси, номер телефона яндекс такси">
+        <style type="text/css">html, body {min-height:100vh; height:100vh;}</style>
+    </head>
+    <body class="g-root g-root_theme_light">
+        <div id="root"></div>
+        <script type="application/json" id="diplodoc-state">
+            {"data":{"leading":true,"data":{"fullScreen":true,"blocks":[{"type":"header-block","title":"&lt;p&gt;Общая поддержка Яндекса&lt;/p&gt;/n","description":"&lt;p&gt;Поддержка для пользователей, которые столкнулись с проблемой или у которых возникли вопросы по сервисам Яндекса. Наша задача — предоставить необходимую помощь в поиске контактов нужной службы поддержки.&lt;/p&gt;/n","additionalInfo":"&lt;p&gt;Сотрудники помогут определить, к какой службе поддержки относится вопрос, а также предоставят контакты для обращения в соответствующие службы.&lt;/p&gt;/n","size":"l","background":{"light":{"image":{"desktop":"https://yastatic.net/s3/doc-binary/docs/support/contact/ru/header.svg","mobile":"https://yastatic.net/s3/doc-binary/docs/support/contact/ru/header.svg"},"color":"#EEF1F7","fullWidth":true,"fullWidthMedia":true},"dark":{"image":{"desktop":"https://yastatic.net/s3/doc-binary/docs/support/contact/ru/header-dark.svg","mobile":"https://yastatic.net/s3/doc-binary/docs/support/contact/ru/header-dark.svg"},"color":"#262626","fullWidth":true,"fullWidthMedia":true}},"resetPaddings":true},{"type":"card-layout-block","resetPaddings":true,"title":"","description":"","children":[{"type":"basic-card","text":"&lt;p&gt;Если у вас возникла проблема, но вы не знаете, к какому сервису относится вопрос, обратитесь в Общую поддержку по номеру или электронной почте.&lt;/p&gt;/n&lt;p&gt;Время работы — круглосуточно.&lt;/p&gt;/n","size":"l"},{"type":"basic-card","title":"&lt;p&gt;Колл-центр&lt;/p&gt;/n","list":[{"icon":{"light":"https://yastatic.net/s3/doc-binary/docs/support/contact/ru/icon-phone.svg","dark":"https://yastatic.net/s3/doc-binary/docs/support/contact/ru/icon-phone-black.svg"},"title":"8 800 250-96-39","text":"Бесплатно по России"},{"icon":{"light":"https://yastatic.net/s3/doc-binary/docs/support/contact/ru/icon-phone.svg","dark":"https://yastatic.net/s3/doc-binary/docs/support/contact/ru/icon-phone-black.svg"},"title":"+7 495 974-35-81"},{"icon":{"light":"https://yastatic.net/s3/doc-binary/docs/support/contact/ru/icon-phone.svg","dark":"https://yastatic.net/s3/doc-binary/docs/support/contact/ru/icon-phone-black.svg"},"title":"+7 495 739-70-00"}],"size":"l","theme":"light"},{"type":"basic-card","title":"&lt;p&gt;Почта&lt;/p&gt;/n","list":[{"icon":{"light":"https://yastatic.net/s3/doc-binary/docs/support/contact/ru/icon-mail.svg","dark":"https://yastatic.net/s3/doc-binary/docs/support/contact/ru/icon-mail-black.svg"},"title":"&lt;a href=\\"support@yandex-team.ru\\" target=\\"_self\\"&gt;support@yandex-team.ru&lt;/a&gt;"}],"theme":"light","size":"l"}],"colSizes":{"all":12,"xl":4,"lg":4,"md":4,"sm":12}}],"links":[]},"meta":{"metadata":[{"name":"generator","content":"Diplodoc Platform vDIPLODOC-VERSION"},{"name":"description","content":"Поддержка для пользователей, которые столкнулись с проблемой или у которых возникли вопросы по сервисам Яндекса."}],"title":"Общая поддержка Яндекса","description":"Поддержка для пользователей, которые столкнулись с проблемой или у которых возникли вопросы по сервисам Яндекса.","keywords":[{"keyword":"Номер телефона Yandex"},{"keyword":"Яндекс контакты {{no-var}}"},{"keyword":"Телефон яндекс такси"},{"keyword":"номер телефона яндекс такси"}],"vcsPath":"index.yaml"},"title":"Общая поддержка Яндекса"},"router":{"pathname":"index","depth":1,"base":"./"},"lang":"ru","langs":["ru"],"viewerInterface":{"toc":true,"search":true,"feedback":true}}
+        </script>
+        <script type="application/javascript">
+            const data = document.querySelector('script#diplodoc-state');
+            window.__DATA__ = JSON.parse((function unescape(string) {
+                return string.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+              })(data.innerText));
+            window.STATIC_CONTENT = false;
+        </script>
+        <script type="application/javascript" defer src="toc.js"></script>
+    </body>
+</html>"
+`;
+
+exports[`Parse and render HTML meta keywords > md2html with structured keywords 2`] = `"window.__DATA__.data.toc = {"href":"index.html","path":"toc.yaml","id":"UUID"};"`;

--- a/tests/e2e/metadata-parse-keywords.spec.ts
+++ b/tests/e2e/metadata-parse-keywords.spec.ts
@@ -1,0 +1,59 @@
+import {readFileSync, readdirSync} from 'node:fs';
+import {join} from 'node:path';
+import {describe, expect, test} from 'vitest';
+
+import {TestAdapter, generateMapTestTemplate, getTestPaths} from '../fixtures';
+
+function findFile(dir: string, predicate: (name: string) => boolean): string | null {
+    try {
+        for (const name of readdirSync(dir, {withFileTypes: true})) {
+            const full = join(dir, name.name);
+
+            if (name.isDirectory()) {
+                const found = findFile(full, predicate);
+
+                if (found) {
+                    return found;
+                }
+            } else if (predicate(name.name)) {
+                return full;
+            }
+        }
+    } catch {
+        return null;
+    }
+
+    return null;
+}
+
+describe('Parse and render HTML meta keywords', () => {
+    generateMapTestTemplate(
+        'md2html with structured keywords',
+        'mocks/metadata/parse-html-keywords',
+        {
+            md2md: false,
+            md2html: true,
+        },
+    );
+
+    test('should parse array of objects with presets and flatten keywords into meta tag', async () => {
+        const {inputPath, outputPath} = getTestPaths('mocks/metadata/parse-html-keywords');
+
+        await TestAdapter.testBuildPass(inputPath, outputPath, {
+            md2md: false,
+            md2html: true,
+        });
+
+        const htmlPath = findFile(outputPath, (n) => n === 'index.html');
+        expect(htmlPath).toBeTruthy();
+        if (!htmlPath) {
+            throw new Error('htmlPath is null');
+        }
+
+        const html = readFileSync(htmlPath, 'utf8');
+
+        expect(html).toMatch(
+            /<meta name="keywords" content="Номер телефона Yandex, Яндекс контакты, Телефон яндекс такси, номер телефона яндекс такси"/,
+        );
+    }, 45000);
+});

--- a/tests/mocks/metadata/parse-html-keywords/input/index.yaml
+++ b/tests/mocks/metadata/parse-html-keywords/input/index.yaml
@@ -1,0 +1,86 @@
+meta:
+  title: Общая поддержка Яндекса
+  description: 'Поддержка для пользователей, которые столкнулись с проблемой или у которых возникли вопросы по сервисам Яндекса.'
+  keywords:
+    - keyword: Номер телефона {{yandex}}
+    - keyword: Яндекс контакты {{no-var}}
+    - keyword: Телефон {{yandex-taxi}}
+    - keyword: номер телефона {{yandex-taxi}}
+
+fullScreen: true
+blocks:
+  - type: 'header-block'
+
+    title: 'Общая поддержка Яндекса'
+    description: 'Поддержка для пользователей, которые столкнулись с проблемой или у которых возникли вопросы по сервисам Яндекса. Наша задача — предоставить необходимую помощь в поиске контактов нужной службы поддержки.'
+    additionalInfo: 'Сотрудники помогут определить, к какой службе поддержки относится вопрос, а также предоставят контакты для обращения в соответствующие службы.'
+    size: 'l'
+    background:
+      light:
+        image:
+          desktop: 'https://yastatic.net/s3/doc-binary/docs/support/contact/ru/header.svg'
+          mobile: 'https://yastatic.net/s3/doc-binary/docs/support/contact/ru/header.svg'
+        color: '#EEF1F7'
+        fullWidth: true
+        fullWidthMedia: true
+      dark:
+        image:
+          desktop: 'https://yastatic.net/s3/doc-binary/docs/support/contact/ru/header-dark.svg'
+          mobile: 'https://yastatic.net/s3/doc-binary/docs/support/contact/ru/header-dark.svg'
+        color: '#262626'
+        fullWidth: true
+        fullWidthMedia: true
+
+    resetPaddings: true
+
+
+  - type: card-layout-block
+    resetPaddings: true
+    title: ''
+    description: ''
+    children:
+      - type: basic-card
+        text: |
+
+              Если у вас возникла проблема, но вы не знаете, к какому сервису относится вопрос, обратитесь в Общую поддержку по номеру или электронной почте.
+
+              Время работы — круглосуточно.
+        size: l
+      - type: basic-card
+        title: Колл-центр
+        list:
+          - icon:
+              light: 'https://yastatic.net/s3/doc-binary/docs/support/contact/ru/icon-phone.svg'
+              dark: 'https://yastatic.net/s3/doc-binary/docs/support/contact/ru/icon-phone-black.svg'
+            title: '8 800 250-96-39'
+            text: 'Бесплатно по России'
+          - icon:
+              light: 'https://yastatic.net/s3/doc-binary/docs/support/contact/ru/icon-phone.svg'
+              dark: 'https://yastatic.net/s3/doc-binary/docs/support/contact/ru/icon-phone-black.svg'
+            title: '+7 495 974-35-81'
+          - icon:
+              light: 'https://yastatic.net/s3/doc-binary/docs/support/contact/ru/icon-phone.svg'
+              dark: 'https://yastatic.net/s3/doc-binary/docs/support/contact/ru/icon-phone-black.svg'
+            title: '+7 495 739-70-00'
+
+        size: l
+
+        theme: light
+      - type: basic-card
+        title: Почта
+        list:
+          - icon:
+              light: 'https://yastatic.net/s3/doc-binary/docs/support/contact/ru/icon-mail.svg'
+              dark: 'https://yastatic.net/s3/doc-binary/docs/support/contact/ru/icon-mail-black.svg'
+            title: <a href="support@yandex-team.ru" target="_self">support@yandex-team.ru</a>
+
+
+
+        theme: light
+        size: l
+    colSizes:
+      all: 12
+      xl: 4
+      lg: 4
+      md: 4
+      sm: 12

--- a/tests/mocks/metadata/parse-html-keywords/input/presets.yaml
+++ b/tests/mocks/metadata/parse-html-keywords/input/presets.yaml
@@ -1,0 +1,3 @@
+default:
+  yandex: Yandex
+  yandex-taxi: яндекс такси

--- a/tests/mocks/metadata/parse-html-keywords/input/toc.yaml
+++ b/tests/mocks/metadata/parse-html-keywords/input/toc.yaml
@@ -1,0 +1,1 @@
+href: index.yaml


### PR DESCRIPTION
## Description
Updated the EntryService rendering logic to correctly flatten keywords in html meta, and added an e2e test to verify the integration and avoid regressions.