### PR TITLE
fix: Add llmsFullMaxSize param DOCSTOOLS-6204

### DIFF
--- a/adr/ADR-009-llms-txt.md
+++ b/adr/ADR-009-llms-txt.md
@@ -1,0 +1,107 @@
+# ADR-009: LLMS files (llms.txt / llms-full.txt)
+
+## Status
+
+Accepted
+
+## Context
+
+The [llmstxt.org](https://llmstxt.org) specification defines a convention for
+providing documentation in a format optimized for Large Language Model (LLM)
+consumption. Two files are generated per TOC:
+
+1. **llms.txt** — a compact index with links to individual pages
+2. **llms-full.txt** — the entire documentation concatenated as self-contained
+   markdown
+
+## Motivation
+
+- Machine-readable access to documentation without HTML parsing
+- LLMs can ingest the full documentation in a single file
+- The artifacts must stay consistent with the built "version" — hidden pages
+  and inactive `{% if %}` branches must not leak
+
+## Decision
+
+### Generation timing
+
+LLMS files are generated in the `AfterAnyRun` hook, so they work for both `md`
+and `html` builds. By that point the TOC is already resolved and filtered
+(vars/conditions, `removeHiddenTocItems`/`removeEmptyTocItems`), which keeps the
+artifacts consistent with the exact "version" produced by single-source
+publishing.
+
+Walking `run.toc.tocs` + `walkEntries` mirrors `SinglePage`.
+
+### llms.txt (index)
+
+A compact index following the llmstxt.org spec:
+
+- Title (`# {toc.title}`)
+- Optional description (`> {llms.description}`)
+- `## Documentation` section with links to each page
+- Footer linking to `llms-full.txt`
+
+Links point to the actual output files: original href in `md`, rendered `.html`
+in `html` builds.
+
+### llms-full.txt (full text)
+
+Assembled with `MarkdownCollector` (the same engine `OutputMd` uses) with
+`SELF_CONTAINED` config — every include is merged into self-contained markdown
+regardless of the build's output format (no md/html fork).
+
+Leading (yaml) pages have no markdown body to inline; they still appear in the
+index above.
+
+### Configuration
+
+```yaml
+llms:
+  enabled: true # or 'md' (only for md output)
+  description: '...' # optional, shown in llms.txt header
+  llmsFullMaxSize: 4M # max size of llms-full.txt (default 4M)
+```
+
+CLI: `--llms` (boolean), `--llms-full-max-size <value>` (default `4M`).
+
+The `enabled` flag accepts `true`, `false`, or `'md'` (enable only for md
+output). When the `--llms` CLI flag is explicitly passed, it overrides the
+config value. When not passed, the config value is used; if no config section
+exists, `md` output defaults to enabled and `html` to disabled.
+
+### llmsFullMaxSize and YFM022
+
+`llms-full.txt` can grow very large for big documentation sets. The
+`llmsFullMaxSize` parameter (default `4M`) limits the file size:
+
+- Size is checked **after each article** is added (not at the end)
+- When the accumulated content would exceed the limit, article ingestion
+  **stops** — remaining articles are skipped
+- `YFM022` is logged as **info** (not error) — the build does not fail
+- The file is still written with whatever content fit within the limit
+
+This differs from `maxAssetSize` (YFM013), which logs an error but still copies
+the file. Here the goal is to produce a useful (if truncated) file for LLM
+consumption, not to block the build.
+
+### Priority resolution
+
+`llmsFullMaxSize` is resolved with priority: CLI flag → YAML config → default
+(`4M`). The default is defined in a single constant
+(`LLMS_FULL_MAX_SIZE_DEFAULT`) in `llms/config.ts`, and the resolution logic is
+encapsulated in `resolveLlmsFullMaxSize()`.
+
+The `fileSizeConverter` utility (shared with `maxAssetSize`, `maxHtmlSize`, etc.)
+converts string values like `'4K'` or `'8M'` to bytes. The `disableIfZero`
+option means `'0'` is treated as "use default", not "0 bytes" — consistent with
+`maxAssetSize`.
+
+## Consequences
+
+- `llms-full.txt` may be truncated for large docs — this is intentional and
+  logged as info, not an error
+- The file always contains at least the title and whatever articles fit
+- `0` means "use default" (not "no limit"), consistent with `maxAssetSize`
+- The artifacts are consistent with the built version: hidden pages and
+  inactive `{% if %}` branches do not leak into either file

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.50.3",
       "license": "MIT",
       "dependencies": {
-        "@diplodoc/ajv": "^0.1.1",
+        "@diplodoc/ajv": "^0.1.2",
         "@diplodoc/client": "^5.9.2",
         "@diplodoc/color-extension": "^0.1.1",
         "@diplodoc/liquid": "^1.5.2",
@@ -1696,9 +1696,9 @@
       }
     },
     "node_modules/@diplodoc/ajv": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@diplodoc/ajv/-/ajv-0.1.1.tgz",
-      "integrity": "sha512-C5JMc9b0F0kybBeGBS+H+zKJNBMjSpfjkHag8buUn3Udf2yNgqj3LB8FvsoWEBBF/fgy0dVUgMQUNWbsUfBQag==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@diplodoc/ajv/-/ajv-0.1.2.tgz",
+      "integrity": "sha512-dV7naE8r8b25Vhyhp8HyfVB4Gowr0kZAq9bbo1MoC/4vD5BerBMeJ4ZtKpJY+Li/3HDwB9zYcMDDmNxw0Vo6gw==",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     ]
   },
   "dependencies": {
-    "@diplodoc/ajv": "^0.1.1",
+    "@diplodoc/ajv": "^0.1.2",
     "@diplodoc/client": "^5.9.2",
     "@diplodoc/color-extension": "^0.1.1",
     "@diplodoc/liquid": "^1.5.2",

--- a/src/commands/build/features/build-stats/index.ts
+++ b/src/commands/build/features/build-stats/index.ts
@@ -241,8 +241,7 @@ export class BuildStats {
                     worker: {
                         maxOldSpace:
                             ((run.config as Hash<unknown>).workerMaxOldSpace as
-                                | number
-                                | undefined) ?? null,
+                                number | undefined) ?? null,
                     },
                 },
                 counters: {

--- a/src/commands/build/features/build-stats/index.ts
+++ b/src/commands/build/features/build-stats/index.ts
@@ -214,6 +214,10 @@ export class BuildStats {
 
             const output = await readOutputSize(run);
 
+            const config = run.config as Hash<unknown>;
+            const workerMaxOldSpace =
+                typeof config.workerMaxOldSpace === 'number' ? config.workerMaxOldSpace : null;
+
             const stats: BuildStatsFormat = {
                 schemaVersion: SCHEMA_VERSION,
                 cli: {
@@ -236,12 +240,10 @@ export class BuildStats {
                     langs: (run.config.langs ?? []).map(toLangCode),
                     inputDir: run.originalInput,
                     outputDir: run.output,
-                    features: collectFeatures(run.config as Hash<unknown>),
+                    features: collectFeatures(config),
                     memoryUsageMb: Math.round(process.memoryUsage().heapUsed / 1024 / 1024),
                     worker: {
-                        maxOldSpace:
-                            ((run.config as Hash<unknown>).workerMaxOldSpace as
-                                number | undefined) ?? null,
+                        maxOldSpace: workerMaxOldSpace,
                     },
                 },
                 counters: {

--- a/src/commands/build/features/llms/config.spec.ts
+++ b/src/commands/build/features/llms/config.spec.ts
@@ -1,0 +1,82 @@
+import {describe, expect, it, vi} from 'vitest';
+
+// Mock only ~/core/config (provides `defined` and `option`).
+// Mock ~/commands/config to prevent its `toArray` parser from failing.
+// fileSizeConverter is imported from ~/commands/build/config — the real
+// implementation is used, no copy-paste.
+vi.mock('~/core/config', () => ({
+    defined: (option: string, ...scopes: Record<string, unknown>[]) => {
+        for (const scope of scopes) {
+            if (option in scope) {
+                return scope[option];
+            }
+        }
+        return null;
+    },
+    option: vi.fn(),
+}));
+
+vi.mock('~/commands/config', () => ({
+    options: {},
+}));
+
+import {resolveLlmsFullMaxSize} from './config';
+
+describe('resolveLlmsFullMaxSize', () => {
+    it('returns default 4M when nothing is set', () => {
+        const result = resolveLlmsFullMaxSize({}, {});
+        expect(result).toBe(4 * 1024 ** 2);
+    });
+
+    it('uses YAML config value (string) when CLI is not set', () => {
+        const result = resolveLlmsFullMaxSize({}, {llmsFullMaxSize: '4K'});
+        expect(result).toBe(4 * 1024);
+    });
+
+    it('uses YAML config value (integer)', () => {
+        const result = resolveLlmsFullMaxSize({}, {llmsFullMaxSize: 8192});
+        expect(result).toBe(8192);
+    });
+
+    it('uses YAML config value with M suffix', () => {
+        const result = resolveLlmsFullMaxSize({}, {llmsFullMaxSize: '8M'});
+        expect(result).toBe(8 * 1024 ** 2);
+    });
+
+    it('CLI value takes priority over YAML', () => {
+        const result = resolveLlmsFullMaxSize(
+            {llmsFullMaxSize: 2 * 1024 ** 2},
+            {llmsFullMaxSize: '4K'},
+        );
+        expect(result).toBe(2 * 1024 ** 2);
+    });
+
+    it('CLI default value (4M) falls back to YAML', () => {
+        // CLI arg equals default (4M) → falls back to YAML
+        const result = resolveLlmsFullMaxSize(
+            {llmsFullMaxSize: 4 * 1024 ** 2},
+            {llmsFullMaxSize: '8M'},
+        );
+        expect(result).toBe(8 * 1024 ** 2);
+    });
+
+    it('YAML "0" uses default (disableIfZero)', () => {
+        const result = resolveLlmsFullMaxSize({}, {llmsFullMaxSize: '0'});
+        expect(result).toBe(4 * 1024 ** 2);
+    });
+
+    it('CLI "0" uses default (disableIfZero)', () => {
+        // fileSizeConverter with disableIfZero converts '0' to default (4M)
+        // so argValue === defaultBytes → falls back to YAML or default
+        const result = resolveLlmsFullMaxSize({llmsFullMaxSize: 4 * 1024 ** 2}, {});
+        expect(result).toBe(4 * 1024 ** 2);
+    });
+
+    it('CLI explicit value with YAML "0" uses CLI', () => {
+        const result = resolveLlmsFullMaxSize(
+            {llmsFullMaxSize: 2 * 1024 ** 2},
+            {llmsFullMaxSize: '0'},
+        );
+        expect(result).toBe(2 * 1024 ** 2);
+    });
+});

--- a/src/commands/build/features/llms/config.ts
+++ b/src/commands/build/features/llms/config.ts
@@ -1,4 +1,8 @@
-import {option} from '~/core/config';
+import {defined, option} from '~/core/config';
+import {fileSizeConverter} from '~/commands/build/config';
+
+/** Default value for llmsFullMaxSize — the single source of truth for '4M'. */
+const LLMS_FULL_MAX_SIZE_DEFAULT = '4M';
 
 const llms = option({
     flags: '--llms',
@@ -7,6 +11,59 @@ const llms = option({
         'Works for both `md` and `html` output.',
 });
 
+const llmsFullMaxSize = option({
+    flags: '--llms-full-max-size <value>',
+    desc: `
+        Maximum size of llms-full.txt. When the accumulated content exceeds this
+        limit, article ingestion stops and YFM022 is logged as info.
+        For disabled use '0' --llms-full-max-size '0'
+        Default: ${LLMS_FULL_MAX_SIZE_DEFAULT}
+
+        Example:
+            {{PROGRAM}} build -i . -o ../build --llms-full-max-size '8M'
+    `,
+    default: LLMS_FULL_MAX_SIZE_DEFAULT,
+    parser: fileSizeConverter({disableIfZero: true}),
+});
+
 export const options = {
     llms,
+    llmsFullMaxSize,
 };
+
+/**
+ * Resolves llmsFullMaxSize from args (CLI, already a number via fileSizeConverter)
+ * or config (YAML, string like '4K' or integer). Priority: explicit CLI → YAML → default.
+ *
+ * - If the .yfm config has `llmsFullMaxSize: '4K'`, fileSizeConverter converts it to 4096 bytes.
+ * - If nothing is set anywhere, the default 4M = 4194304 bytes is returned.
+ * - `'0'` means "use default" (disableIfZero), consistent with maxAssetSize.
+ */
+export function resolveLlmsFullMaxSize(args: Hash, config: Hash): number {
+    const argValue = defined('llmsFullMaxSize', args);
+    const configValue = defined('llmsFullMaxSize', config);
+
+    const defaultBytes = fileSizeConverter({disableIfZero: true})(
+        LLMS_FULL_MAX_SIZE_DEFAULT,
+        LLMS_FULL_MAX_SIZE_DEFAULT,
+    );
+
+    // If CLI is explicitly set (differs from default) — use it
+    if (argValue !== null && argValue !== defaultBytes) {
+        return argValue as number;
+    }
+
+    // If YAML config is set — parse and use it
+    if (configValue !== null) {
+        if (typeof configValue === 'number') {
+            return configValue;
+        }
+        return (
+            fileSizeConverter({disableIfZero: true})(configValue, LLMS_FULL_MAX_SIZE_DEFAULT) ??
+            (defaultBytes as number)
+        );
+    }
+
+    // Default
+    return defaultBytes as number;
+}

--- a/src/commands/build/features/llms/index.spec.ts
+++ b/src/commands/build/features/llms/index.spec.ts
@@ -1,4 +1,4 @@
-import type {Run} from '~/commands/build';
+import type {BuildArgs, Run} from '~/commands/build';
 import type {LlmsConfig} from './index';
 
 import {beforeEach, describe, expect, it, vi} from 'vitest';
@@ -20,6 +20,22 @@ vi.mock('~/core/program', () => ({
     }),
 }));
 
+vi.mock('~/core/config', () => ({
+    defined: (option: string, ...scopes: Record<string, unknown>[]) => {
+        for (const scope of scopes) {
+            if (option in scope) {
+                return scope[option];
+            }
+        }
+        return null;
+    },
+    option: vi.fn(),
+}));
+
+vi.mock('~/commands/config', () => ({
+    options: {},
+}));
+
 vi.mock('../output-md/collect', () => {
     return {
         SELF_CONTAINED: 'self-contained',
@@ -36,6 +52,7 @@ function createMockRun(
         outputFormat?: OutputFormat;
         enabled?: boolean;
         description?: string;
+        llmsFullMaxSize?: number;
     } = {},
 ): Run {
     return {
@@ -44,6 +61,7 @@ function createMockRun(
             llms: {
                 enabled: options.enabled ?? true,
                 description: options.description ?? 'AI Assistant Context Description',
+                llmsFullMaxSize: options.llmsFullMaxSize ?? 4 * 1024 ** 2,
             },
         } as unknown as LlmsConfig & {outputFormat: OutputFormat},
         meta: {
@@ -55,17 +73,32 @@ function createMockRun(
         logger: {
             warn: vi.fn(),
             error: vi.fn(),
+            info: vi.fn(),
         },
     } as unknown as Run;
 }
 
-const makeLlmsArgs = (llms: boolean | null) => ({llms}) as any;
+const makeLlmsArgs = (llms: boolean | null) => ({llms}) as unknown as BuildArgs;
+
+/**
+ * Exposes private methods of Llms for testing.
+ * Avoids `any` while allowing access to private members.
+ */
+type TestableLlms = {
+    resolveLlmsEnabled(
+        args: BuildArgs,
+        config: Partial<LlmsConfig['llms']> | undefined,
+        onlyMd: boolean,
+    ): boolean;
+    renderIndex(run: Run, title: string, entries: unknown[]): Promise<string>;
+    renderFull(run: Run, title: string, entries: unknown[]): Promise<string>;
+};
 
 describe('LLMs Plugin Architecture', () => {
-    let llmsInstance: any;
+    let llmsInstance: TestableLlms;
 
     beforeEach(() => {
-        llmsInstance = new Llms();
+        llmsInstance = new Llms() as unknown as TestableLlms;
     });
 
     describe('resolveLlmsEnabled logic', () => {
@@ -253,6 +286,74 @@ describe('LLMs Plugin Architecture', () => {
             const result = await llmsInstance.renderFull(run, 'Full Book', entries);
 
             expect(result.trim()).toBe('# Full Book');
+        });
+
+        it('should add all articles when within llmsFullMaxSize limit', async () => {
+            const run = createMockRun({llmsFullMaxSize: 1024 * 1024});
+            const entries = [
+                {
+                    href: normalizedPath('page1.md'),
+                    path: normalizedPath('docs/page1.md'),
+                    name: 'Page 1',
+                },
+                {
+                    href: normalizedPath('page2.md'),
+                    path: normalizedPath('docs/page2.md'),
+                    name: 'Page 2',
+                },
+            ];
+
+            const result = await llmsInstance.renderFull(run, 'Full Book', entries);
+
+            expect(result).toContain('# Full Book');
+            expect(result).toContain('Collected Markdown Content');
+            expect(run.logger.info).not.toHaveBeenCalled();
+        });
+
+        it('should stop adding articles and log YFM022 when limit is exceeded', async () => {
+            // Set a very small limit so the first article already exceeds it
+            const run = createMockRun({llmsFullMaxSize: 10});
+            const entries = [
+                {
+                    href: normalizedPath('page1.md'),
+                    path: normalizedPath('docs/page1.md'),
+                    name: 'Page 1',
+                },
+                {
+                    href: normalizedPath('page2.md'),
+                    path: normalizedPath('docs/page2.md'),
+                    name: 'Page 2',
+                },
+            ];
+
+            const result = await llmsInstance.renderFull(run, 'Full Book', entries);
+
+            // Title is always present
+            expect(result).toContain('# Full Book');
+            // The first article should NOT be added (it exceeds the 10-byte limit)
+            expect(result).not.toContain('Collected Markdown Content');
+            // YFM022 should be logged as info
+            expect(run.logger.info).toHaveBeenCalledWith(
+                'YFM022',
+                expect.stringContaining('size limit reached'),
+            );
+        });
+
+        it('should use default llmsFullMaxSize (4M) when not specified', async () => {
+            const run = createMockRun();
+            const entries = [
+                {
+                    href: normalizedPath('page1.md'),
+                    path: normalizedPath('docs/page1.md'),
+                    name: 'Page 1',
+                },
+            ];
+
+            const result = await llmsInstance.renderFull(run, 'Full Book', entries);
+
+            expect(result).toContain('# Full Book');
+            expect(result).toContain('Collected Markdown Content');
+            expect(run.logger.info).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/commands/build/features/llms/index.ts
+++ b/src/commands/build/features/llms/index.ts
@@ -11,19 +11,25 @@ import {OutputFormat} from '~/commands/build/config';
 
 import {MarkdownCollector, SELF_CONTAINED} from '../output-md/collect';
 
-import {options} from './config';
+import {options, resolveLlmsFullMaxSize} from './config';
 
 export const LLMS_INDEX_FILENAME = 'llms.txt';
 export const LLMS_FULL_FILENAME = 'llms-full.txt';
 
+const LLMS_SEPARATOR = '\n\n';
+const LLMS_SEPARATOR_SIZE = Buffer.byteLength(LLMS_SEPARATOR, 'utf8');
+const LLMS_TRAILING_NEWLINE = '\n';
+
 export type LlmsArgs = {
     llms: boolean;
+    llmsFullMaxSize: number;
 };
 
 export type LlmsConfig = {
     llms: {
         enabled: boolean;
         description?: string;
+        llmsFullMaxSize: number;
     };
 };
 
@@ -58,6 +64,7 @@ export class Llms {
     apply(program: Build) {
         getBaseHooks(program).Command.tap('Llms', (command: Command) => {
             command.addOption(options.llms);
+            command.addOption(options.llmsFullMaxSize);
         });
 
         getBaseHooks(program).Config.tap('Llms', (config, args) => {
@@ -65,11 +72,13 @@ export class Llms {
             const onlyMd = config.outputFormat === OutputFormat.md;
 
             const enabled = this.resolveLlmsEnabled(args, config.llms, onlyMd);
+            const llmsFullMaxSize = resolveLlmsFullMaxSize(args, config.llms || {});
 
             config.llms = {
                 ...(typeof config.llms === 'object' ? config.llms : {}),
                 enabled,
                 description: llmsDescription,
+                llmsFullMaxSize,
             };
 
             return config;
@@ -182,30 +191,70 @@ export class Llms {
             parts.push(`# ${title}`);
         }
 
+        const maxSize = run.config.llms.llmsFullMaxSize;
+        let currentSize = Buffer.byteLength(
+            parts.join(LLMS_SEPARATOR) + LLMS_TRAILING_NEWLINE,
+            'utf8',
+        );
+        let limitReached = false;
+
         // Assemble fully self-contained markdown (all includes merged),
         // independent of the build's output format — see MarkdownCollector.
         const collector = new MarkdownCollector(run, SELF_CONTAINED);
 
         for (const entry of entries) {
+            if (limitReached) {
+                break;
+            }
+
             // Leading (yaml) pages have no markdown body to inline; they still
             // appear in the index above.
             if (!entry.path.endsWith('.md')) {
                 continue;
             }
 
-            let body = '';
-            try {
-                body = (await collector.collect(entry.path)).trim();
-            } catch (error) {
-                run.logger.warn(`llms-full.txt: unable to assemble ${entry.path}: ${error}`);
+            const body = await this.collectBody(run, collector, entry.path);
+
+            if (!body) {
                 continue;
             }
 
-            if (body) {
-                parts.push(body);
+            // Check whether adding this article would exceed the size limit.
+            const candidateSize =
+                currentSize +
+                (parts.length > 0 ? LLMS_SEPARATOR_SIZE : 0) +
+                Buffer.byteLength(body, 'utf8');
+
+            if (candidateSize > maxSize) {
+                run.logger.info(
+                    'YFM022',
+                    `llms-full.txt: size limit reached at ${currentSize} bytes ` +
+                        `(limit ${maxSize}), stopped before adding ${entry.path}`,
+                );
+                limitReached = true;
+                break;
             }
+
+            parts.push(body);
+            currentSize = candidateSize;
         }
 
-        return parts.join('\n\n') + '\n';
+        return parts.join(LLMS_SEPARATOR) + LLMS_TRAILING_NEWLINE;
+    }
+
+    private async collectBody(
+        run: Run,
+        collector: MarkdownCollector,
+        entryPath: NormalizedPath,
+    ): Promise<string> {
+        try {
+            const body = await collector.collect(entryPath);
+
+            return body.trim();
+        } catch (error) {
+            run.logger.warn(`llms-full.txt: unable to assemble ${entryPath}: ${error}`);
+
+            return '';
+        }
     }
 }

--- a/src/commands/build/features/llms/index.ts
+++ b/src/commands/build/features/llms/index.ts
@@ -196,17 +196,12 @@ export class Llms {
             parts.join(LLMS_SEPARATOR) + LLMS_TRAILING_NEWLINE,
             'utf8',
         );
-        let limitReached = false;
 
         // Assemble fully self-contained markdown (all includes merged),
         // independent of the build's output format — see MarkdownCollector.
         const collector = new MarkdownCollector(run, SELF_CONTAINED);
 
         for (const entry of entries) {
-            if (limitReached) {
-                break;
-            }
-
             // Leading (yaml) pages have no markdown body to inline; they still
             // appear in the index above.
             if (!entry.path.endsWith('.md')) {
@@ -231,7 +226,6 @@ export class Llms {
                     `llms-full.txt: size limit reached at ${currentSize} bytes ` +
                         `(limit ${maxSize}), stopped before adding ${entry.path}`,
                 );
-                limitReached = true;
                 break;
             }
 

--- a/tests/e2e/llms.spec.ts
+++ b/tests/e2e/llms.spec.ts
@@ -1,4 +1,6 @@
-import {describe, test} from 'vitest';
+import {readFile} from 'node:fs/promises';
+import {join} from 'node:path';
+import {describe, expect, test} from 'vitest';
 
 import {TestAdapter, compareDirectories, getTestPaths} from '../fixtures';
 
@@ -20,5 +22,42 @@ describe('llms.txt', () => {
 
         await compareDirectories(outputPath);
         await compareDirectories(`${outputPath}-html`);
+    });
+
+    test('llms-full.txt respects --llms-full-max-size limit', async () => {
+        const {inputPath, outputPath} = getTestPaths('mocks/llms');
+
+        // Set a very small limit (1K) — after the first article
+        // adding should stop, YFM022 is logged as info
+        await TestAdapter.testBuildPass(inputPath, outputPath, {
+            md2md: true,
+            md2html: false,
+            args: '--llms --llms-full-max-size 1K',
+        });
+
+        // Verify that llms-full.txt exists and its size does not exceed the limit
+        const fullContent = await readFile(join(outputPath, 'llms-full.txt'), 'utf8');
+        const fullSize = Buffer.byteLength(fullContent, 'utf8');
+
+        // The file should contain the title and at most one article
+        expect(fullContent).toContain('# My Product');
+        expect(fullSize).toBeLessThanOrEqual(1024);
+    });
+
+    test('llms-full.txt respects llms.llmsFullMaxSize from .yfm config', async () => {
+        const {inputPath, outputPath} = getTestPaths('mocks/llms-max-size');
+
+        await TestAdapter.testBuildPass(inputPath, outputPath, {
+            md2md: true,
+            md2html: false,
+            args: '--llms',
+        });
+
+        // Verify that llms-full.txt exists and its size does not exceed the 2K limit
+        const fullContent = await readFile(join(outputPath, 'llms-full.txt'), 'utf8');
+        const fullSize = Buffer.byteLength(fullContent, 'utf8');
+
+        expect(fullContent).toContain('# My Product');
+        expect(fullSize).toBeLessThanOrEqual(2 * 1024);
     });
 });

--- a/tests/mocks/llms-max-size/input/.yfm
+++ b/tests/mocks/llms-max-size/input/.yfm
@@ -1,0 +1,5 @@
+allowHtml: true
+llms:
+  enabled: true
+  description: 'Documentation with llmsFullMaxSize from config.'
+  llmsFullMaxSize: 2K

--- a/tests/mocks/llms-max-size/input/_includes/requirements.md
+++ b/tests/mocks/llms-max-size/input/_includes/requirements.md
@@ -1,0 +1,4 @@
+## Requirements
+
+- Node.js 18+
+- 2 GB RAM

--- a/tests/mocks/llms-max-size/input/api.md
+++ b/tests/mocks/llms-max-size/input/api.md
@@ -1,0 +1,9 @@
+---
+description: Full reference of the public HTTP endpoints.
+---
+
+# API Reference
+
+## GET /things
+
+Returns the list of things.

--- a/tests/mocks/llms-max-size/input/beta.md
+++ b/tests/mocks/llms-max-size/input/beta.md
@@ -1,0 +1,4 @@
+# Beta Feature
+
+This page is gated behind `when: showBeta` and must NOT appear in the llms
+artifacts for the default (showBeta = false) version.

--- a/tests/mocks/llms-max-size/input/index.md
+++ b/tests/mocks/llms-max-size/input/index.md
@@ -1,0 +1,8 @@
+---
+title: Overview
+description: What this product is and how to get started.
+---
+
+# Overview
+
+Welcome to **My Product** — the documentation home page.

--- a/tests/mocks/llms-max-size/input/presets.yaml
+++ b/tests/mocks/llms-max-size/input/presets.yaml
@@ -1,0 +1,2 @@
+default:
+  showBeta: false

--- a/tests/mocks/llms-max-size/input/start.md
+++ b/tests/mocks/llms-max-size/input/start.md
@@ -1,0 +1,9 @@
+---
+description: Install the product and build your first project.
+---
+
+# Getting Started
+
+Run the installer and create your first project.
+
+{% include [Requirements](_includes/requirements.md) %}

--- a/tests/mocks/llms-max-size/input/toc.yaml
+++ b/tests/mocks/llms-max-size/input/toc.yaml
@@ -1,0 +1,11 @@
+title: My Product
+href: index.md
+
+items:
+  - name: Getting Started
+    href: start.md
+  - name: API Reference
+    href: api.md
+  - name: Beta Feature
+    href: beta.md
+    when: showBeta


### PR DESCRIPTION
Implemented the `llmsFullMaxSize` parameter to limit the size of `llms-full.txt`. All changes are verified: TypeScript build without errors, 29 unit tests, and 27 ajv tests pass.

## What has been done

### Code
1. **[`llms/config.ts`](packages/cli/src/commands/build/features/llms/config.ts:1)** — added the constant `LLMS_FULL_MAX_SIZE_DEFAULT = '4M" (the only default location), the CLI option `--llms-full-max-size` with `fileSizeConverter`, and the function `resolveLlmsFullMaxSize()` with priority: CLI → YAML → default
2. **[`llms/index.ts`](packages/cli/src/commands/build/features/llms/index.ts:1)** - extended types `LlmsArgs`/`LlmsConfig` (`llmsFullMaxSize: number`), option registered in `Command.tap`, resolving is called in `Config.tap`, in `renderFull()` added size check via `Buffer.byteLength` after each article with interrupt and logging `YFM022` as `info`
3. **[`yfm-schema.yaml`](packages/ajv/src/yaml/yfm-schema.yaml:531)** - added the `llmsFullMaxSize` property (`$ref: '#/definitions/FileSize'`) to the `llms` section, and the JSON schema was regenerated

### Tests
4. **[`config.spec.ts`](packages/cli/src/commands/build/features/llms/config.spec.ts:1)** — 9 unit-tests on `resolveLlmsFullMaxSize` (CLI/YAML/default priorities, conversion `4K`→4096, `disableIfZero`)
5. **[`index.spec.ts`](packages/cli/src/commands/build/features/llms/index.spec.ts:1)** — updated mock `createMockRun` (added `llmsFullMaxSize` and `info`), 3 new tests on `renderFull` with a limit
6. **[`llms.spec.ts`](packages/cli/tests/e2e/llms.spec.ts:1)** — 2 e2e tests: `--llms-full-max-size 1K` and `llms.llmsFullMaxSize` from `.yfm`
7. **[`mocks/llms-max-size/`](packages/cli/tests/mocks/llms-max-size/input/.yfm:1)** — new fixture with `llmsFullMaxSize: 2K` in `.yfm`

### Documentation
8. **[`ADR-009-llms-txt.md`](packages/cli/adr/ADR-009-llms-txt.md:1)** — ADR for the entire llms feature (generation, configuration, `llmsFullMaxSize` and YFM022, priorities)