### PR TITLE
feat(translate): pass document context to AI translation prompts

### DIFF
--- a/src/commands/translate/providers/ai/config.ts
+++ b/src/commands/translate/providers/ai/config.ts
@@ -69,7 +69,7 @@ const systemPrompt = option({
     desc: `
         System prompt for the LLM. Accepts a string or a path to a file.
 
-        Supports placeholders: {{source}}, {{target}}, {{glossary}}, {{separator}}, {{fragments}}.
+        Supports placeholders: {{source}}, {{target}}, {{glossary}}, {{context}}, {{separator}}, {{fragments}}.
 
         By default the user prompt is appended to the built-in technical-translator system prompt.
         Use --prompt-mode replace to fully replace the default.
@@ -80,7 +80,7 @@ const userPrompt = option({
     flags: '--user-prompt <value>',
     desc: `
         User prompt template. Accepts a string or a path to a file.
-        Supports placeholders: {{source}}, {{target}}, {{glossary}}, {{separator}}, {{fragments}}, {{text}}.
+        Supports placeholders: {{source}}, {{target}}, {{glossary}}, {{context}}, {{separator}}, {{fragments}}, {{text}}.
     `,
 });
 

--- a/src/commands/translate/providers/ai/prompts.spec.ts
+++ b/src/commands/translate/providers/ai/prompts.spec.ts
@@ -90,5 +90,32 @@ describe('translate ai prompts', () => {
 
             expect(user.content).toContain('Value of {{source}} var');
         });
+
+        it('should render document context into the user message', () => {
+            const [, user] = buildMessages(['Hello'], {
+                ...config,
+                context: 'document "Quickstart" (file docs/ru/index.md)',
+            });
+
+            expect(user.content).toContain(
+                'Document context: document "Quickstart" (file docs/ru/index.md).',
+            );
+        });
+
+        it('should not render context prefix when context is absent', () => {
+            const [, user] = buildMessages(['Hello'], config);
+
+            expect(user.content).not.toContain('Document context');
+        });
+
+        it('should substitute context placeholder in a custom system prompt', () => {
+            const [system] = buildMessages(['Hello'], {
+                ...config,
+                context: 'file docs/ru/index.md',
+                systemPrompt: 'You are translating {{context}}',
+            });
+
+            expect(system.content).toContain('You are translating Document context');
+        });
     });
 });

--- a/src/commands/translate/providers/ai/prompts.ts
+++ b/src/commands/translate/providers/ai/prompts.ts
@@ -14,6 +14,8 @@ export type PromptConfig = {
     sourceLanguage: string;
     targetLanguage: string;
     glossaryPairs: GlossaryPair[];
+    /** Human-readable document context, e.g. `document "Quickstart" (file docs/ru/index.md)`. */
+    context?: string;
 };
 
 const FRAGMENT_SEPARATOR = '<<<§§§>>>';
@@ -34,6 +36,8 @@ export const DEFAULT_SYSTEM_PROMPT = dedent`
 export const DEFAULT_USER_PROMPT = dedent`
     Translate the following fragments from {{source}} into {{target}}.
     Return the translated fragments in the same order, separated by the exact delimiter line "{{separator}}".
+
+    {{context}}
 
     {{glossary}}
 
@@ -116,6 +120,7 @@ export function buildMessages(fragments: string[], config: PromptConfig): ChatMe
         source: sourceLanguage,
         target: targetLanguage,
         glossary: renderGlossary(glossaryPairs),
+        context: config.context ? `Document context: ${config.context}.` : '',
         separator: FRAGMENT_SEPARATOR,
         fragments: joined,
         text: joined,

--- a/src/commands/translate/providers/ai/provider.spec.ts
+++ b/src/commands/translate/providers/ai/provider.spec.ts
@@ -5,7 +5,7 @@ import type {Defer} from './utils';
 
 import {describe, expect, it, vi} from 'vitest';
 
-import {makeTranslator} from './provider';
+import {extractTitle, makeTranslator} from './provider';
 import {FRAGMENT_SEPARATOR, splitFragments} from './prompts';
 import {LLMAuthError} from './utils';
 
@@ -68,6 +68,21 @@ function makeParams(client: LLMClient, config: Partial<AITranslationConfig> = {}
 const translated = (fragments: string[]) => fragments.map((text) => `T:${text}`);
 
 describe('translate ai provider', () => {
+    describe('extractTitle', () => {
+        it('should extract the first H1 from markdown', () => {
+            expect(extractTitle('Intro\n\n# Page title\n\n## Sub')).toBe('Page title');
+        });
+
+        it('should extract the title field from yaml documents', () => {
+            expect(extractTitle({title: 'Toc title', items: []})).toBe('Toc title');
+        });
+
+        it('should return undefined when there is no title', () => {
+            expect(extractTitle('plain text')).toBeUndefined();
+            expect(extractTitle({items: []})).toBeUndefined();
+        });
+    });
+
     describe('makeTranslator', () => {
         it('should translate texts through the client', async () => {
             const client = makeClient(translated);
@@ -146,6 +161,32 @@ describe('translate ai provider', () => {
             expect(result).toEqual([oversized]);
             expect(client.complete).not.toHaveBeenCalled();
             expect(warn).toHaveBeenCalledWith('file.md', expect.stringContaining('too big'));
+        });
+
+        it('should pass document context into prompts', async () => {
+            const client = makeClient(translated);
+            const {params} = makeParams(client, {systemPrompt: 'CONTEXT: {{context}}'});
+            const translate = makeTranslator(params);
+
+            await translate('docs/ru/index.md', ['One'], {title: 'Quickstart'});
+
+            const [messages] = vi.mocked(client.complete).mock.calls[0];
+            expect(messages[0].content).toContain(
+                'CONTEXT: Document context: document "Quickstart" (file docs/ru/index.md).',
+            );
+        });
+
+        it('should fall back to file path context without title', async () => {
+            const client = makeClient(translated);
+            const {params} = makeParams(client, {systemPrompt: 'CONTEXT: {{context}}'});
+            const translate = makeTranslator(params);
+
+            await translate('docs/ru/index.md', ['One']);
+
+            const [messages] = vi.mocked(client.complete).mock.calls[0];
+            expect(messages[0].content).toContain(
+                'CONTEXT: Document context: file docs/ru/index.md.',
+            );
         });
 
         it('should estimate usage without client calls on dry run', async () => {

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -129,8 +129,13 @@ export type DocContext = {
  */
 export function extractTitle(data: unknown): string | undefined {
     if (typeof data === 'string') {
-        const match = data.match(/^#[ \t]+(.+)$/m);
-        return match?.[1].trim();
+        for (const line of data.split('\n')) {
+            const trimmed = line.trim();
+            if (trimmed.startsWith('# ') || trimmed.startsWith('#\t')) {
+                return trimmed.slice(2).trim();
+            }
+        }
+        return undefined;
     }
 
     if (data && typeof data === 'object') {

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -117,7 +117,35 @@ type ProcessorParams = {
     translate: Translate;
 };
 
-type Translate = (path: string, texts: string[]) => Promise<string[]>;
+type Translate = (path: string, texts: string[], context?: DocContext) => Promise<string[]>;
+
+export type DocContext = {
+    title?: string;
+};
+
+/**
+ * Extracts a human-readable document title to use as translation context:
+ * the first H1 for markdown, the `title` field for yaml documents.
+ */
+export function extractTitle(data: unknown): string | undefined {
+    if (typeof data === 'string') {
+        const match = data.match(/^#[ \t]+(.+)$/m);
+        return match?.[1].trim();
+    }
+
+    if (data && typeof data === 'object') {
+        const title = (data as {title?: unknown}).title;
+        if (typeof title === 'string') {
+            return title;
+        }
+    }
+
+    return undefined;
+}
+
+function describeDocument(path: string, context?: DocContext): string {
+    return context?.title ? `document "${context.title}" (file ${path})` : `file ${path}`;
+}
 
 function makeProcessor(params: ProcessorParams) {
     const {input, output, sourceLanguage, targetLanguage, vars, translate} = params;
@@ -171,7 +199,7 @@ function makeProcessor(params: ProcessorParams) {
             return;
         }
 
-        const parts = await translate(path, units);
+        const parts = await translate(path, units, {title: extractTitle(content.data)});
 
         content.set(compose(skeleton, parts, {useSource: true, schemas, ajvOptions}));
         await content.dump(outputPath);
@@ -205,7 +233,7 @@ export function makeTranslator(params: TranslatorParams): Translate {
 
     const schedule = scheduler(maxConcurrency);
 
-    async function translateBatch(fragments: string[]): Promise<string[]> {
+    async function translateBatch(fragments: string[], context: string): Promise<string[]> {
         if (!fragments.length) {
             return [];
         }
@@ -217,6 +245,7 @@ export function makeTranslator(params: TranslatorParams): Translate {
             sourceLanguage,
             targetLanguage,
             glossaryPairs,
+            context,
         });
 
         if (dryRun) {
@@ -251,9 +280,13 @@ export function makeTranslator(params: TranslatorParams): Translate {
         return parts;
     }
 
-    async function translateWithFallback(path: string, fragments: string[]): Promise<string[]> {
+    async function translateWithFallback(
+        path: string,
+        fragments: string[],
+        context: string,
+    ): Promise<string[]> {
         try {
-            return await translateBatch(fragments);
+            return await translateBatch(fragments, context);
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
             if (error instanceof LLMResponseError && fragments.length > 1) {
@@ -263,7 +296,7 @@ export function makeTranslator(params: TranslatorParams): Translate {
                 );
                 const result: string[] = [];
                 for (const fragment of fragments) {
-                    const single = await translateBatch([fragment]);
+                    const single = await translateBatch([fragment], context);
                     result.push(single[0]);
                 }
                 return result;
@@ -272,7 +305,8 @@ export function makeTranslator(params: TranslatorParams): Translate {
         }
     }
 
-    return async function translate(path: string, texts: string[]) {
+    return async function translate(path: string, texts: string[], docContext?: DocContext) {
+        const context = describeDocument(path, docContext);
         const promises: Promise<string>[] = [];
         const requests: Promise<void>[] = [];
         let buffer: string[] = [];
@@ -286,7 +320,7 @@ export function makeTranslator(params: TranslatorParams): Translate {
             requests.push(
                 schedule(async () => {
                     try {
-                        const translated = await translateWithFallback(path, batch);
+                        const translated = await translateWithFallback(path, batch, context);
                         translated.forEach((text, i) => {
                             cache.get(batch[i])?.resolve(text);
                         });


### PR DESCRIPTION
## Summary

Follow-up to #1906. Units are translated as isolated fragments, so the model does not know what page it is translating - terminology and tone can drift between files (the segment-in-context problem).

Now every batch carries document context:

- first H1 for markdown files, `title` field for yaml documents, plus the file path;
- rendered into the default user prompt as `Document context: document "..." (file ...)`;
- available as the `{{context}}` placeholder in custom `--system-prompt` / `--user-prompt`.

The unit dedupe cache is intentionally still keyed by unit text only: identical units across files reuse the first translation, context is a hint, not a cache dimension. This keeps dedupe and cross-file consistency.

DOCSTOOLS-6385
