### PR TITLE
feat(translate): persistent translation cache for AI providers

### DIFF
--- a/src/commands/translate/index.spec.ts
+++ b/src/commands/translate/index.spec.ts
@@ -406,6 +406,15 @@ describe('Translate command', () => {
                     judge: true,
                     judgeThreshold: 80,
                 });
+
+                test('should resolve cache dir arg', '--cache-dir .translate-cache', {
+                    // @ts-ignore - asymmetric matcher in expected config
+                    cacheDir: expect.stringContaining('.translate-cache'),
+                });
+
+                test('should handle no-cache arg', '--cache-dir .translate-cache --no-cache', {
+                    cacheDir: undefined,
+                });
             });
 
             describe('yandexgpt', () => {

--- a/src/commands/translate/providers/ai/config.ts
+++ b/src/commands/translate/providers/ai/config.ts
@@ -118,6 +118,21 @@ const judgeThreshold = option({
     defaultInfo: 70,
 });
 
+const cacheDir = option({
+    flags: '--cache-dir <path>',
+    desc: `
+        Enable a persistent translation cache in the given directory.
+        Repeated runs reuse stored translations and send only new or changed
+        units to the LLM. The cache is reset when the provider, model,
+        prompts or glossary change.
+    `,
+});
+
+const noCache = option({
+    flags: '--no-cache',
+    desc: 'Disable the persistent translation cache for this run.',
+});
+
 const glossaryExample = gray(dedent`
     glossaryPairs:
       - sourceText: string
@@ -185,6 +200,8 @@ export const options = {
     judge,
     judgeModel,
     judgeThreshold,
+    cacheDir,
+    noCache,
     temperature,
     maxOutputTokens,
     maxBatchTokens,

--- a/src/commands/translate/providers/ai/index.ts
+++ b/src/commands/translate/providers/ai/index.ts
@@ -4,7 +4,7 @@ import type {LLMClient} from './clients/types';
 import type {GlossaryPair, PromptMode} from './prompts';
 
 import {ok} from 'node:assert';
-import {join} from 'node:path';
+import {join, resolve} from 'node:path';
 
 import {getHooks as getBaseHooks} from '~/core/program';
 import {getHooks} from '~/commands/translate';
@@ -60,6 +60,8 @@ type Args = {
     judge?: boolean;
     judgeModel?: string;
     judgeThreshold?: number;
+    cacheDir?: string;
+    cache?: boolean;
     temperature?: number;
     maxOutputTokens?: number;
     maxBatchTokens?: number;
@@ -81,6 +83,7 @@ type Config = {
     judge: boolean;
     judgeModel?: string;
     judgeThreshold: number;
+    cacheDir?: AbsolutePath;
     temperature: number;
     maxOutputTokens: number;
     maxBatchTokens: number;
@@ -205,6 +208,8 @@ export class Extension {
                         .addOption(options.judge)
                         .addOption(options.judgeModel)
                         .addOption(options.judgeThreshold)
+                        .addOption(options.cacheDir)
+                        .addOption(options.noCache)
                         .addOption(options.temperature)
                         .addOption(options.maxOutputTokens)
                         .addOption(options.maxBatchTokens)
@@ -289,6 +294,16 @@ export class Extension {
                     );
                     config.retry = intOr(defined('retry', args, config), 3);
                     config.timeout = intOr(defined('timeout', args, config), DEFAULT_TIMEOUT);
+
+                    let cacheDir: AbsolutePath | undefined;
+                    if (args.cache !== false) {
+                        if (own<string, 'cacheDir'>(args, 'cacheDir')) {
+                            cacheDir = resolve(args.cacheDir) as AbsolutePath;
+                        } else if (own<string, 'cacheDir'>(config, 'cacheDir')) {
+                            cacheDir = config.resolve(config.cacheDir);
+                        }
+                    }
+                    config.cacheDir = cacheDir;
 
                     let glossary: AbsolutePath | undefined;
                     if (own<string, 'glossary'>(args, 'glossary')) {

--- a/src/commands/translate/providers/ai/provider.spec.ts
+++ b/src/commands/translate/providers/ai/provider.spec.ts
@@ -3,11 +3,14 @@ import type {AITranslationConfig} from './index';
 import type {LLMClient} from './clients/types';
 import type {Defer} from './utils';
 
+import {mkdtempSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 import {describe, expect, it, vi} from 'vitest';
 
 import {extractTitle, makeTranslator} from './provider';
 import {FRAGMENT_SEPARATOR, splitFragments} from './prompts';
-import {LLMAuthError} from './utils';
+import {LLMAuthError, TranslationStore, cacheFingerprint} from './utils';
 
 type FakeComplete = (fragments: string[], call: number) => string[] | Error;
 
@@ -33,13 +36,18 @@ function makeClient(complete: FakeComplete) {
     return client;
 }
 
-function makeParams(client: LLMClient, config: Partial<AITranslationConfig> = {}) {
+function makeParams(
+    client: LLMClient,
+    config: Partial<AITranslationConfig> = {},
+    store?: TranslationStore,
+) {
     const warn = vi.fn();
-    const stat = {inputTokens: 0, outputTokens: 0, requests: 0, bytes: 0};
+    const stat = {inputTokens: 0, outputTokens: 0, requests: 0, bytes: 0, cached: 0};
     const cache = new Map<string, Defer>();
 
     return {
         params: {
+            store,
             client,
             config: {
                 userPrompt: '{{fragments}}',
@@ -187,6 +195,64 @@ describe('translate ai provider', () => {
             expect(messages[0].content).toContain(
                 'CONTEXT: Document context: file docs/ru/index.md.',
             );
+        });
+
+        it('should reuse translations from the persistent store', async () => {
+            const file = join(mkdtempSync(join(tmpdir(), 'yfm-ai-store-')), 'store.json');
+            const fingerprint = cacheFingerprint({model: 'fake'});
+
+            const warmup = new TranslationStore(file, fingerprint);
+            warmup.load();
+            warmup.set('One', 'T:One');
+            warmup.flush();
+
+            const client = makeClient(translated);
+            const store = new TranslationStore(file, fingerprint);
+            store.load();
+            const {params, stat} = makeParams(client, {}, store);
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', ['One']);
+
+            expect(result).toEqual(['T:One']);
+            expect(client.complete).not.toHaveBeenCalled();
+            expect(stat.cached).toBe(1);
+        });
+
+        it('should save fresh translations into the persistent store', async () => {
+            const file = join(mkdtempSync(join(tmpdir(), 'yfm-ai-store-')), 'store.json');
+            const fingerprint = cacheFingerprint({model: 'fake'});
+
+            const client = makeClient(translated);
+            const store = new TranslationStore(file, fingerprint);
+            store.load();
+            const {params} = makeParams(client, {}, store);
+            const translate = makeTranslator(params);
+
+            await translate('file.md', ['One', 'Two']);
+            store.flush();
+
+            const reopened = new TranslationStore(file, fingerprint);
+            reopened.load();
+
+            expect(reopened.get('One')).toBe('T:One');
+            expect(reopened.get('Two')).toBe('T:Two');
+        });
+
+        it('should not poison the store on dry run', async () => {
+            const file = join(mkdtempSync(join(tmpdir(), 'yfm-ai-store-')), 'store.json');
+            const fingerprint = cacheFingerprint({model: 'fake'});
+
+            const client = makeClient(translated);
+            const store = new TranslationStore(file, fingerprint);
+            store.load();
+            const {params} = makeParams(client, {dryRun: true}, store);
+            const translate = makeTranslator(params);
+
+            await translate('file.md', ['One']);
+            store.flush();
+
+            expect(store.get('One')).toBeUndefined();
         });
 
         it('should estimate usage without client calls on dry run', async () => {

--- a/src/commands/translate/providers/ai/provider.spec.ts
+++ b/src/commands/translate/providers/ai/provider.spec.ts
@@ -150,7 +150,6 @@ describe('translate ai provider', () => {
             second?.load();
 
             expect(second?.get('Привет')).toBeUndefined();
->>>>>>> 8d19fa54 (chore(translate): cover store creation and cache args with tests)
         });
     });
 

--- a/src/commands/translate/providers/ai/provider.spec.ts
+++ b/src/commands/translate/providers/ai/provider.spec.ts
@@ -3,12 +3,12 @@ import type {AITranslationConfig} from './index';
 import type {LLMClient} from './clients/types';
 import type {Defer} from './utils';
 
-import {mkdtempSync} from 'node:fs';
+import {existsSync, mkdtempSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {describe, expect, it, vi} from 'vitest';
 
-import {extractTitle, makeTranslator} from './provider';
+import {extractTitle, makeStore, makeTranslator} from './provider';
 import {FRAGMENT_SEPARATOR, splitFragments} from './prompts';
 import {LLMAuthError, TranslationStore, cacheFingerprint} from './utils';
 
@@ -88,6 +88,69 @@ describe('translate ai provider', () => {
         it('should return undefined when there is no title', () => {
             expect(extractTitle('plain text')).toBeUndefined();
             expect(extractTitle({items: []})).toBeUndefined();
+        });
+    });
+
+    describe('makeStore', () => {
+        it('should return undefined without cacheDir', () => {
+            const client = makeClient(translated);
+
+            expect(makeStore(client, {} as AITranslationConfig, 'ru', 'en')).toBeUndefined();
+        });
+
+        it('should create a store file per provider and language pair', async () => {
+            const dir = mkdtempSync(join(tmpdir(), 'yfm-ai-store-'));
+            const client = makeClient(translated);
+            const config = {
+                cacheDir: dir,
+                model: 'model',
+                promptMode: 'append',
+                glossaryPairs: [],
+            } as unknown as AITranslationConfig;
+
+            const store = makeStore(client, config, 'ru', 'en');
+
+            expect(store).toBeDefined();
+            store?.load();
+            store?.set('Привет', 'Hello');
+            store?.flush();
+
+            const reopened = makeStore(client, config, 'ru', 'en');
+            reopened?.load();
+
+            expect(reopened?.get('Привет')).toBe('Hello');
+            expect(existsSync(join(dir, 'fake.ru-en.json'))).toBe(true);
+        });
+
+        it('should reset stored translations when the model changes', () => {
+            const dir = mkdtempSync(join(tmpdir(), 'yfm-ai-store-'));
+            const client = makeClient(translated);
+            const base = {
+                cacheDir: dir,
+                promptMode: 'append',
+                glossaryPairs: [],
+            };
+
+            const first = makeStore(
+                client,
+                {...base, model: 'a'} as unknown as AITranslationConfig,
+                'ru',
+                'en',
+            );
+            first?.load();
+            first?.set('Привет', 'Hello');
+            first?.flush();
+
+            const second = makeStore(
+                client,
+                {...base, model: 'b'} as unknown as AITranslationConfig,
+                'ru',
+                'en',
+            );
+            second?.load();
+
+            expect(second?.get('Привет')).toBeUndefined();
+>>>>>>> 8d19fa54 (chore(translate): cover store creation and cache args with tests)
         });
     });
 

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -340,7 +340,7 @@ type TranslatorParams = {
  * The fingerprint covers everything that affects the output, so changing
  * the model, prompts or glossary safely resets the cache.
  */
-function makeStore(
+export function makeStore(
     client: LLMClient,
     config: AITranslationConfig,
     sourceLanguage: string,

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -23,12 +23,7 @@ import {
     cacheFingerprint,
     estimateTokens,
 } from './utils';
-import {
-    DEFAULT_SYSTEM_PROMPT,
-    DEFAULT_USER_PROMPT,
-    buildMessages,
-    splitFragments,
-} from './prompts';
+import {DEFAULT_SYSTEM_PROMPT, DEFAULT_USER_PROMPT, buildMessages, splitFragments} from './prompts';
 import {judgeTranslations} from './judge';
 
 const SOURCE_PREVIEW_LIMIT = 80;

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -23,7 +23,12 @@ import {
     cacheFingerprint,
     estimateTokens,
 } from './utils';
-import {buildMessages, splitFragments} from './prompts';
+import {
+    DEFAULT_SYSTEM_PROMPT,
+    DEFAULT_USER_PROMPT,
+    buildMessages,
+    splitFragments,
+} from './prompts';
 import {judgeTranslations} from './judge';
 
 const SOURCE_PREVIEW_LIMIT = 80;
@@ -351,6 +356,8 @@ export function makeStore(
     }
 
     const file = join(config.cacheDir, `${client.name}.${sourceLanguage}-${targetLanguage}.json`);
+    // Built-in prompts are part of the fingerprint too: when a CLI update
+    // changes them, stored translations are stale and must not be served.
     const fingerprint = cacheFingerprint({
         provider: client.name,
         model: config.model,
@@ -359,6 +366,8 @@ export function makeStore(
         promptMode: config.promptMode,
         systemPrompt: config.systemPrompt,
         userPrompt: config.userPrompt,
+        defaultSystemPrompt: DEFAULT_SYSTEM_PROMPT,
+        defaultUserPrompt: DEFAULT_USER_PROMPT,
         glossaryPairs: config.glossaryPairs,
     });
 

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -14,7 +14,15 @@ import {LogLevel} from '~/core/logger';
 import {FileLoader, TranslateError, compose, extract, resolveSchemas} from '../../utils';
 import {TranslateLogger} from '../../logger';
 
-import {Defer, LLMResponseError, backoff, bytes, estimateTokens} from './utils';
+import {
+    Defer,
+    LLMResponseError,
+    TranslationStore,
+    backoff,
+    bytes,
+    cacheFingerprint,
+    estimateTokens,
+} from './utils';
 import {buildMessages, splitFragments} from './prompts';
 import {judgeTranslations} from './judge';
 
@@ -51,7 +59,10 @@ export class Provider {
         try {
             for (const target of targets) {
                 const cache = new Map<string, Defer>();
-                const stat = {inputTokens: 0, outputTokens: 0, requests: 0, bytes: 0};
+                const stat = {inputTokens: 0, outputTokens: 0, requests: 0, bytes: 0, cached: 0};
+                const store = makeStore(client, config, source.language, target.language);
+
+                store?.load();
 
                 const translate = makeTranslator({
                     client,
@@ -59,6 +70,7 @@ export class Provider {
                     sourceLanguage: source.language,
                     targetLanguage: target.language,
                     cache,
+                    store,
                     stat,
                     logger: this.logger,
                 });
@@ -92,6 +104,8 @@ export class Provider {
                         try {
                             this.logger.translate(file);
                             await processFile(file);
+                            // Flush after every file to keep progress on crashes.
+                            store?.flush();
                             if (!dryRun) {
                                 this.logger.translated(file);
                             }
@@ -109,9 +123,12 @@ export class Provider {
                     }),
                 );
 
+                store?.flush();
+
                 this.logger.stat(
                     `requests: ${stat.requests} input-tokens: ${stat.inputTokens} ` +
-                        `output-tokens: ${stat.outputTokens} bytes: ${stat.bytes}`,
+                        `output-tokens: ${stat.outputTokens} bytes: ${stat.bytes} ` +
+                        `cached-units: ${stat.cached}`,
                 );
 
                 if (pairs.length) {
@@ -307,12 +324,49 @@ type TranslatorParams = {
     sourceLanguage: string;
     targetLanguage: string;
     cache: Map<string, Defer>;
-    stat: {inputTokens: number; outputTokens: number; requests: number; bytes: number};
+    store?: TranslationStore;
+    stat: {
+        inputTokens: number;
+        outputTokens: number;
+        requests: number;
+        bytes: number;
+        cached: number;
+    };
     logger: Logger;
 };
 
+/**
+ * Creates a persistent translation store when --cache-dir is configured.
+ * The fingerprint covers everything that affects the output, so changing
+ * the model, prompts or glossary safely resets the cache.
+ */
+function makeStore(
+    client: LLMClient,
+    config: AITranslationConfig,
+    sourceLanguage: string,
+    targetLanguage: string,
+): TranslationStore | undefined {
+    if (!config.cacheDir) {
+        return undefined;
+    }
+
+    const file = join(config.cacheDir, `${client.name}.${sourceLanguage}-${targetLanguage}.json`);
+    const fingerprint = cacheFingerprint({
+        provider: client.name,
+        model: config.model,
+        source: sourceLanguage,
+        target: targetLanguage,
+        promptMode: config.promptMode,
+        systemPrompt: config.systemPrompt,
+        userPrompt: config.userPrompt,
+        glossaryPairs: config.glossaryPairs,
+    });
+
+    return new TranslationStore(file, fingerprint);
+}
+
 export function makeTranslator(params: TranslatorParams): Translate {
-    const {client, config, sourceLanguage, targetLanguage, cache, stat, logger} = params;
+    const {client, config, sourceLanguage, targetLanguage, cache, store, stat, logger} = params;
     const {
         systemPrompt,
         userPrompt,
@@ -418,6 +472,9 @@ export function makeTranslator(params: TranslatorParams): Translate {
                         const translated = await translateWithFallback(path, batch, context);
                         translated.forEach((text, i) => {
                             cache.get(batch[i])?.resolve(text);
+                            if (!dryRun) {
+                                store?.set(batch[i], text);
+                            }
                         });
                     } catch (error) {
                         // Reject and evict pending defers, otherwise files sharing
@@ -446,6 +503,13 @@ export function makeTranslator(params: TranslatorParams): Translate {
                     `Skip document part for translation. Part is too big (~${tokens} tokens > ${maxBatchTokens}).`,
                 );
                 promises.push(Promise.resolve(text));
+                continue;
+            }
+
+            const stored = store?.get(text);
+            if (stored !== undefined) {
+                stat.cached++;
+                promises.push(Promise.resolve(stored));
                 continue;
             }
 

--- a/src/commands/translate/providers/ai/utils/cache.spec.ts
+++ b/src/commands/translate/providers/ai/utils/cache.spec.ts
@@ -1,0 +1,67 @@
+import {mkdtempSync, readFileSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {describe, expect, it} from 'vitest';
+
+import {TranslationStore, cacheFingerprint} from './cache';
+
+const tmp = () => join(mkdtempSync(join(tmpdir(), 'yfm-translate-cache-')), 'store.json');
+
+describe('translate ai cache', () => {
+    describe('TranslationStore', () => {
+        it('should persist translations between instances', () => {
+            const file = tmp();
+            const fingerprint = cacheFingerprint({model: 'a'});
+
+            const first = new TranslationStore(file, fingerprint);
+            first.load();
+            first.set('Привет', 'Hello');
+            first.flush();
+
+            const second = new TranslationStore(file, fingerprint);
+            second.load();
+
+            expect(second.get('Привет')).toBe('Hello');
+            expect(second.get('Другое')).toBeUndefined();
+        });
+
+        it('should reset the cache when the fingerprint changes', () => {
+            const file = tmp();
+
+            const first = new TranslationStore(file, cacheFingerprint({model: 'a'}));
+            first.load();
+            first.set('Привет', 'Hello');
+            first.flush();
+
+            const second = new TranslationStore(file, cacheFingerprint({model: 'b'}));
+            second.load();
+
+            expect(second.get('Привет')).toBeUndefined();
+        });
+
+        it('should survive a corrupted cache file', () => {
+            const file = tmp();
+            writeFileSync(file, 'not a json');
+
+            const store = new TranslationStore(file, cacheFingerprint({}));
+
+            expect(() => store.load()).not.toThrow();
+            expect(store.get('Привет')).toBeUndefined();
+        });
+
+        it('should not write the file until something changes', () => {
+            const file = tmp();
+            const store = new TranslationStore(file, cacheFingerprint({}));
+
+            store.load();
+            store.flush();
+
+            expect(() => readFileSync(file)).toThrow();
+
+            store.set('Привет', 'Hello');
+            store.flush();
+
+            expect(JSON.parse(readFileSync(file, 'utf8')).translations).toBeTruthy();
+        });
+    });
+});

--- a/src/commands/translate/providers/ai/utils/cache.ts
+++ b/src/commands/translate/providers/ai/utils/cache.ts
@@ -1,0 +1,89 @@
+import {createHash} from 'node:crypto';
+import {existsSync, mkdirSync, readFileSync, writeFileSync} from 'node:fs';
+import {dirname} from 'node:path';
+
+const VERSION = 1;
+
+type StoreFile = {
+    version: number;
+    fingerprint: string;
+    translations: Record<string, string>;
+};
+
+function hash(value: string): string {
+    return createHash('sha256').update(value).digest('hex');
+}
+
+/**
+ * Builds a cache fingerprint from everything that affects translation output.
+ * When any of these change, stored translations are stale and the cache resets.
+ */
+export function cacheFingerprint(parts: unknown): string {
+    return hash(JSON.stringify(parts));
+}
+
+/**
+ * File-backed translation memory: unit text hash -> translation.
+ *
+ * The store is loaded once per run and flushed after each processed file,
+ * so repeated runs only send new or changed units to the LLM.
+ */
+export class TranslationStore {
+    private readonly file: string;
+
+    private readonly fingerprint: string;
+
+    private translations: Record<string, string> = {};
+
+    private dirty = false;
+
+    constructor(file: string, fingerprint: string) {
+        this.file = file;
+        this.fingerprint = fingerprint;
+    }
+
+    load() {
+        if (!existsSync(this.file)) {
+            return;
+        }
+
+        try {
+            const data = JSON.parse(readFileSync(this.file, 'utf8')) as StoreFile;
+            if (
+                data.version === VERSION &&
+                data.fingerprint === this.fingerprint &&
+                data.translations
+            ) {
+                this.translations = data.translations;
+            }
+        } catch {
+            // A corrupted cache is not fatal - start from scratch.
+        }
+    }
+
+    get(text: string): string | undefined {
+        return this.translations[hash(text)];
+    }
+
+    set(text: string, translation: string) {
+        this.translations[hash(text)] = translation;
+        this.dirty = true;
+    }
+
+    flush() {
+        if (!this.dirty) {
+            return;
+        }
+
+        mkdirSync(dirname(this.file), {recursive: true});
+        writeFileSync(
+            this.file,
+            JSON.stringify({
+                version: VERSION,
+                fingerprint: this.fingerprint,
+                translations: this.translations,
+            }),
+        );
+        this.dirty = false;
+    }
+}

--- a/src/commands/translate/providers/ai/utils/index.ts
+++ b/src/commands/translate/providers/ai/utils/index.ts
@@ -7,6 +7,7 @@ export {
     LLMResponseError,
     throwLLMError,
 } from './errors';
+export {TranslationStore, cacheFingerprint} from './cache';
 
 export class Defer<T = string> {
     resolve!: (text: T) => void;


### PR DESCRIPTION
## Summary

Follow-up to #1906. Repeated `translate` runs used to retranslate the whole doc set: tokens were spent again and already reviewed translations drifted between runs because LLM output is not deterministic. This is the standard translation-memory problem; TMS products and doc-translation pipelines solve it with a per-segment cache.

### What's added

- `--cache-dir <path>` (or `cacheDir` in config) enables a file-backed translation memory: unit hash -> translation, one JSON file per provider and language pair (`<provider>.<source>-<target>.json`).
- Units found in the store never reach the LLM; the run stat line reports `cached-units: N`.
- The cache fingerprint covers provider, model, prompts, prompt mode and glossary - changing any of them resets stored translations instead of serving stale ones.
- `--no-cache` disables the store for a single run.
- The store is flushed after every processed file, so an interrupted run keeps its progress.
- `--dry-run` reads the cache (estimates reflect the real remaining spend) but never writes it.

The in-memory in-flight dedupe from #1906 stays as is; the store sits in front of it.

DOCSTOOLS-6386
