### PR TITLE
fix(translate): stop relying on the model echoing xliff wrappers

### DIFF
--- a/src/commands/translate/providers/ai/provider.spec.ts
+++ b/src/commands/translate/providers/ai/provider.spec.ts
@@ -8,7 +8,7 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {describe, expect, it, vi} from 'vitest';
 
-import {extractTitle, makeStore, makeTranslator} from './provider';
+import {extractTitle, makeStore, makeTranslator, unwrapUnit} from './provider';
 import {FRAGMENT_SEPARATOR, splitFragments} from './prompts';
 import {LLMAuthError, TranslationStore, cacheFingerprint} from './utils';
 
@@ -184,6 +184,26 @@ describe('translate ai provider', () => {
         });
     });
 
+    describe('unwrapUnit', () => {
+        it('should split the xliff source wrapper from the text', () => {
+            const unit = '<source xml:space="preserve">Привет, <g id="g-1">мир</g></source>';
+
+            expect(unwrapUnit(unit)).toEqual({
+                open: '<source xml:space="preserve">',
+                text: 'Привет, <g id="g-1">мир</g>',
+                close: '</source>',
+            });
+        });
+
+        it('should pass plain text through unchanged', () => {
+            expect(unwrapUnit('Просто текст')).toEqual({
+                open: '',
+                text: 'Просто текст',
+                close: '',
+            });
+        });
+    });
+
     describe('makeTranslator', () => {
         it('should translate texts through the client', async () => {
             const client = makeClient(translated);
@@ -346,6 +366,23 @@ describe('translate ai provider', () => {
             store.flush();
 
             expect(store.get('One')).toBeUndefined();
+        });
+
+        it('should strip the xliff wrapper before prompting and restore it after', async () => {
+            const unit = '<source xml:space="preserve">Привет, <g id="g-1">мир</g></source>';
+            const client = makeClient(translated);
+            const {params} = makeParams(client);
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', [unit]);
+
+            expect(result).toEqual([
+                '<source xml:space="preserve">T:Привет, <g id="g-1">мир</g></source>',
+            ]);
+
+            const [messages] = vi.mocked(client.complete).mock.calls[0];
+            expect(messages[1].content).not.toContain('<source');
+            expect(messages[1].content).toContain('Привет, <g id="g-1">мир</g>');
         });
 
         it('should log a request line when a batch is sent', async () => {

--- a/src/commands/translate/providers/ai/provider.spec.ts
+++ b/src/commands/translate/providers/ai/provider.spec.ts
@@ -3,12 +3,12 @@ import type {AITranslationConfig} from './index';
 import type {LLMClient} from './clients/types';
 import type {Defer} from './utils';
 
-import {existsSync, mkdtempSync} from 'node:fs';
+import {existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {describe, expect, it, vi} from 'vitest';
 
-import {extractTitle, makeStore, makeTranslator, unwrapUnit} from './provider';
+import {Provider, extractTitle, makeStore, makeTranslator, unwrapUnit} from './provider';
 import {FRAGMENT_SEPARATOR, splitFragments} from './prompts';
 import {LLMAuthError, TranslationStore, cacheFingerprint} from './utils';
 
@@ -77,7 +77,83 @@ function makeParams(
 
 const translated = (fragments: string[]) => fragments.map((text) => `T:${text}`);
 
+function makeFullClient() {
+    return {
+        name: 'fake',
+        complete: vi.fn(async (messages: {role: string; content: string}[]) => {
+            // Judge requests are recognized by the reviewer system prompt.
+            if (messages[0].content.includes('strict reviewer')) {
+                const count = (messages[1].content.match(/^\[\d+\]$/gm) || []).length;
+                const scores = Array.from({length: count}, (_, i) => ({
+                    index: i + 1,
+                    score: 50 + i,
+                    issue: 'test issue',
+                }));
+                return {text: JSON.stringify(scores)};
+            }
+
+            const fragments = splitFragments(messages[messages.length - 1].content);
+            return {
+                text: fragments.map((text) => 'T:' + text).join(`\n${FRAGMENT_SEPARATOR}\n`),
+            };
+        }),
+    } as LLMClient;
+}
+
 describe('translate ai provider', () => {
+    describe('Provider.translate', () => {
+        it('should translate files end to end and write a judge report', async () => {
+            const root = mkdtempSync(join(tmpdir(), 'yfm-ai-e2e-'));
+            const input = join(root, 'docs');
+            const output = join(root, 'out');
+            mkdirSync(join(input, 'ru'), {recursive: true});
+            writeFileSync(join(input, 'ru', 'test.md'), '# Заголовок\n\nПривет, мир.\n');
+
+            const client = makeFullClient();
+            const provider = new Provider(() => client, {} as never);
+            const logger = {
+                translate: vi.fn(),
+                translated: vi.fn(),
+                request: vi.fn(),
+                stat: vi.fn(),
+                warn: vi.fn(),
+                error: vi.fn(),
+            };
+            Object.assign(provider, {logger});
+
+            await provider.translate(['ru/test.md'], {
+                input,
+                output,
+                source: {language: 'ru', locale: 'RU'},
+                target: [{language: 'en', locale: 'US'}],
+                vars: {},
+                dryRun: false,
+                judge: true,
+                judgeThreshold: 80,
+                userPrompt: '{{fragments}}',
+                promptMode: 'append',
+                glossaryPairs: [],
+                temperature: 0,
+                maxOutputTokens: 200,
+                maxBatchTokens: 100,
+                maxConcurrency: 2,
+                retry: 0,
+            } as unknown as AITranslationConfig);
+
+            const result = readFileSync(join(output, 'en', 'test.md'), 'utf8');
+            expect(result).toContain('T:Заголовок');
+            expect(result).toContain('T:Привет, мир.');
+            expect(logger.error).not.toHaveBeenCalled();
+
+            const report = JSON.parse(
+                readFileSync(join(output, 'translate-quality.en.json'), 'utf8'),
+            );
+            expect(report.scored).toBeGreaterThan(0);
+            expect(report.low).toBeGreaterThan(0);
+            expect(logger.warn).toHaveBeenCalledWith('ru/test.md', expect.stringContaining('/100'));
+        });
+    });
+
     describe('extractTitle', () => {
         it('should extract the first H1 from markdown', () => {
             expect(extractTitle('Intro\n\n# Page title\n\n## Sub')).toBe('Page title');
@@ -394,6 +470,16 @@ describe('translate ai provider', () => {
 
             expect(result).toEqual(['T:One']);
             expect(client.complete).toHaveBeenCalledTimes(1);
+        });
+
+        it('should drop a stray leading delimiter in the response', async () => {
+            const client = makeClient((fragments) => ['', ...translated(fragments)]);
+            const {params} = makeParams(client);
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', ['One']);
+
+            expect(result).toEqual(['T:One']);
         });
 
         it('should keep the source text when the model returns an empty translation', async () => {

--- a/src/commands/translate/providers/ai/provider.spec.ts
+++ b/src/commands/translate/providers/ai/provider.spec.ts
@@ -385,6 +385,27 @@ describe('translate ai provider', () => {
             expect(messages[1].content).toContain('Привет, <g id="g-1">мир</g>');
         });
 
+        it('should tolerate a stray trailing delimiter in the response', async () => {
+            const client = makeClient((fragments) => [...translated(fragments), '']);
+            const {params} = makeParams(client);
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', ['One']);
+
+            expect(result).toEqual(['T:One']);
+            expect(client.complete).toHaveBeenCalledTimes(1);
+        });
+
+        it('should keep the source text when the model returns an empty translation', async () => {
+            const client = makeClient(() => ['', '']);
+            const {params} = makeParams(client);
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', ['Fake file']);
+
+            expect(result).toEqual(['Fake file']);
+        });
+
         it('should log a request line when a batch is sent', async () => {
             const client = makeClient(translated);
             const {params, request} = makeParams(client);

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -80,9 +80,14 @@ export class Provider {
                     config.judge && !dryRun
                         ? (path: string, units: string[], parts: string[]) => {
                               units.forEach((unit, index) => {
-                                  if (parts[index] !== undefined && parts[index] !== unit) {
-                                      pairs.push({path, source: unit, translation: parts[index]});
+                                  if (parts[index] === undefined || parts[index] === unit) {
+                                      return;
                                   }
+                                  pairs.push({
+                                      path,
+                                      source: unwrapUnit(unit).text,
+                                      translation: unwrapUnit(parts[index]).text,
+                                  });
                               });
                           }
                         : undefined;
@@ -234,6 +239,38 @@ type Translate = (path: string, texts: string[], context?: DocContext) => Promis
 export type DocContext = {
     title?: string;
 };
+
+const SOURCE_OPEN = '<source';
+const SOURCE_CLOSE = '</source>';
+
+type UnitWrapper = {
+    open: string;
+    text: string;
+    close: string;
+};
+
+/**
+ * Units produced by extract are wrapped in an XLIFF `<source>` element.
+ * The wrapper is transport framing for compose, not translatable content:
+ * it is stripped before prompting and restored on the translated text,
+ * so composing does not depend on the model echoing XML back.
+ */
+export function unwrapUnit(unit: string): UnitWrapper {
+    const trimmed = unit.trim();
+
+    if (trimmed.startsWith(SOURCE_OPEN) && trimmed.endsWith(SOURCE_CLOSE)) {
+        const open = trimmed.indexOf('>');
+        if (open !== -1) {
+            return {
+                open: trimmed.slice(0, open + 1),
+                text: trimmed.slice(open + 1, -SOURCE_CLOSE.length),
+                close: SOURCE_CLOSE,
+            };
+        }
+    }
+
+    return {open: '', text: unit, close: ''};
+}
 
 /**
  * Extracts a human-readable document title to use as translation context:
@@ -403,15 +440,19 @@ export function makeTranslator(params: TranslatorParams): Translate {
             return [];
         }
 
-        const messages = buildMessages(fragments, {
-            systemPrompt,
-            userPrompt,
-            promptMode,
-            sourceLanguage,
-            targetLanguage,
-            glossaryPairs,
-            context,
-        });
+        const wrappers = fragments.map(unwrapUnit);
+        const messages = buildMessages(
+            wrappers.map((wrapper) => wrapper.text),
+            {
+                systemPrompt,
+                userPrompt,
+                promptMode,
+                sourceLanguage,
+                targetLanguage,
+                glossaryPairs,
+                context,
+            },
+        );
 
         if (dryRun) {
             const inputTokens = messages.reduce((sum, m) => sum + estimateTokens(m.content), 0);
@@ -442,7 +483,11 @@ export function makeTranslator(params: TranslatorParams): Translate {
             );
         }
 
-        return parts;
+        // Restore the wrapper; unwrap defensively in case the model echoed it.
+        return parts.map((part, index) => {
+            const {open, close} = wrappers[index];
+            return open + unwrapUnit(part).text + close;
+        });
     }
 
     async function translateWithFallback(

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -10,6 +10,7 @@ import {asyncify, eachLimit} from 'async';
 import liquid from '@diplodoc/transform/lib/liquid';
 
 import {LogLevel} from '~/core/logger';
+import {normalizePath} from '~/core/utils';
 
 import {FileLoader, TranslateError, compose, extract, resolveSchemas} from '../../utils';
 import {TranslateLogger} from '../../logger';
@@ -316,12 +317,12 @@ function makeProcessor(params: ProcessorParams) {
         const outputPath = (path: string) =>
             join(
                 outputRoot,
-                path
-                    .replace(inputRoot, '')
-                    // Dump passes an absolute path: on Windows it comes with
-                    // backslashes, so normalize before the language swap.
-                    .replace(/\\/g, '/')
-                    .replace('/' + sourceLanguage + '/', '/' + targetLanguage + '/'),
+                // Dump passes an absolute path with os-dependent separators:
+                // normalize to posix before the language swap.
+                normalizePath(path.replace(inputRoot, '')).replace(
+                    '/' + sourceLanguage + '/',
+                    '/' + targetLanguage + '/',
+                ),
             );
 
         const content = new FileLoader(inputPath);

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -10,9 +10,15 @@ import {asyncify, eachLimit} from 'async';
 import liquid from '@diplodoc/transform/lib/liquid';
 
 import {LogLevel} from '~/core/logger';
-import {normalizePath} from '~/core/utils';
 
-import {FileLoader, TranslateError, compose, extract, resolveSchemas} from '../../utils';
+import {
+    FileLoader,
+    TranslateError,
+    compose,
+    extract,
+    languageRepath,
+    resolveSchemas,
+} from '../../utils';
 import {TranslateLogger} from '../../logger';
 
 import {
@@ -314,16 +320,7 @@ function makeProcessor(params: ProcessorParams) {
         }
 
         const inputPath = join(inputRoot, path);
-        const outputPath = (path: string) =>
-            join(
-                outputRoot,
-                // Dump passes an absolute path with os-dependent separators:
-                // normalize to posix before the language swap.
-                normalizePath(path.replace(inputRoot, '')).replace(
-                    '/' + sourceLanguage + '/',
-                    '/' + targetLanguage + '/',
-                ),
-            );
+        const outputPath = languageRepath({inputRoot, outputRoot, sourceLanguage, targetLanguage});
 
         const content = new FileLoader(inputPath);
         await content.load();

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -318,6 +318,9 @@ function makeProcessor(params: ProcessorParams) {
                 outputRoot,
                 path
                     .replace(inputRoot, '')
+                    // Dump passes an absolute path: on Windows it comes with
+                    // backslashes, so normalize before the language swap.
+                    .replace(/\\/g, '/')
                     .replace('/' + sourceLanguage + '/', '/' + targetLanguage + '/'),
             );
 

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -477,6 +477,16 @@ export function makeTranslator(params: TranslatorParams): Translate {
 
         const parts = splitFragments(result.text);
 
+        // Models sometimes emit stray edge delimiters (e.g. a lone separator
+        // for a fragment they decided to keep as is) - empty edge parts are
+        // framing noise, not translations.
+        while (parts.length > fragments.length && parts[parts.length - 1] === '') {
+            parts.pop();
+        }
+        while (parts.length > fragments.length && parts[0] === '') {
+            parts.shift();
+        }
+
         if (parts.length !== fragments.length) {
             throw new LLMResponseError(
                 `Expected ${fragments.length} fragments in LLM response, got ${parts.length}`,
@@ -484,9 +494,11 @@ export function makeTranslator(params: TranslatorParams): Translate {
         }
 
         // Restore the wrapper; unwrap defensively in case the model echoed it.
+        // An empty translation of a non-empty fragment is never valid - keep
+        // the source text instead (matches the built-in prompt rules).
         return parts.map((part, index) => {
-            const {open, close} = wrappers[index];
-            return open + unwrapUnit(part).text + close;
+            const {open, text, close} = wrappers[index];
+            return open + (unwrapUnit(part).text || text) + close;
         });
     }
 

--- a/src/commands/translate/providers/yandex/provider.ts
+++ b/src/commands/translate/providers/yandex/provider.ts
@@ -9,6 +9,7 @@ import axios, {AxiosError} from 'axios';
 import liquid from '@diplodoc/transform/lib/liquid';
 
 import {LogLevel} from '~/core/logger';
+import {normalizePath} from '~/core/utils';
 
 import {FileLoader, TranslateError, compose, extract, resolveSchemas} from '../../utils';
 import {TranslateLogger} from '../../logger';
@@ -278,12 +279,12 @@ function processor(params: TranslatorParams, translate: Translate) {
         const output = (path: string) =>
             join(
                 outputRoot,
-                path
-                    .replace(inputRoot, '')
-                    // Dump passes an absolute path: on Windows it comes with
-                    // backslashes, so normalize before the language swap.
-                    .replace(/\\/g, '/')
-                    .replace('/' + sourceLanguage + '/', '/' + targetLanguage + '/'),
+                // Dump passes an absolute path with os-dependent separators:
+                // normalize to posix before the language swap.
+                normalizePath(path.replace(inputRoot, '')).replace(
+                    '/' + sourceLanguage + '/',
+                    '/' + targetLanguage + '/',
+                ),
             );
 
         const content = new FileLoader(inputPath);

--- a/src/commands/translate/providers/yandex/provider.ts
+++ b/src/commands/translate/providers/yandex/provider.ts
@@ -280,6 +280,9 @@ function processor(params: TranslatorParams, translate: Translate) {
                 outputRoot,
                 path
                     .replace(inputRoot, '')
+                    // Dump passes an absolute path: on Windows it comes with
+                    // backslashes, so normalize before the language swap.
+                    .replace(/\\/g, '/')
                     .replace('/' + sourceLanguage + '/', '/' + targetLanguage + '/'),
             );
 

--- a/src/commands/translate/providers/yandex/provider.ts
+++ b/src/commands/translate/providers/yandex/provider.ts
@@ -9,9 +9,15 @@ import axios, {AxiosError} from 'axios';
 import liquid from '@diplodoc/transform/lib/liquid';
 
 import {LogLevel} from '~/core/logger';
-import {normalizePath} from '~/core/utils';
 
-import {FileLoader, TranslateError, compose, extract, resolveSchemas} from '../../utils';
+import {
+    FileLoader,
+    TranslateError,
+    compose,
+    extract,
+    languageRepath,
+    resolveSchemas,
+} from '../../utils';
 import {TranslateLogger} from '../../logger';
 
 import {AuthError, Defer, LimitExceed, RequestError, bytes} from './utils';
@@ -276,16 +282,7 @@ function processor(params: TranslatorParams, translate: Translate) {
         }
 
         const inputPath = join(inputRoot, path);
-        const output = (path: string) =>
-            join(
-                outputRoot,
-                // Dump passes an absolute path with os-dependent separators:
-                // normalize to posix before the language swap.
-                normalizePath(path.replace(inputRoot, '')).replace(
-                    '/' + sourceLanguage + '/',
-                    '/' + targetLanguage + '/',
-                ),
-            );
+        const output = languageRepath({inputRoot, outputRoot, sourceLanguage, targetLanguage});
 
         const content = new FileLoader(inputPath);
 

--- a/src/commands/translate/utils/fs.ts
+++ b/src/commands/translate/utils/fs.ts
@@ -14,6 +14,8 @@ import {
     tocSchemaJson,
 } from '@diplodoc/ajv';
 
+import {normalizePath} from '~/core/utils';
+
 const TRANSLATABLE_EXTENSIONS = ['.md', '.yaml'];
 
 type AssetsConfig = {
@@ -191,6 +193,30 @@ export class FileLoader<T = string | JSONObject> {
             await writeFile(output, text, 'utf8');
         }
     }
+}
+
+/**
+ * Builds the repath function for FileLoader.dump: maps an absolute input
+ * path into the output root, swapping the source language path segment
+ * for the target one. Dump passes os-dependent separators - normalize
+ * to posix before the language swap.
+ */
+export function languageRepath(params: {
+    inputRoot: string;
+    outputRoot: string;
+    sourceLanguage: string;
+    targetLanguage: string;
+}) {
+    const {inputRoot, outputRoot, sourceLanguage, targetLanguage} = params;
+
+    return (path: string) =>
+        join(
+            outputRoot,
+            normalizePath(path.replace(inputRoot, '')).replace(
+                '/' + sourceLanguage + '/',
+                '/' + targetLanguage + '/',
+            ),
+        );
 }
 
 async function loadFile<T = string | JSONObject>(path: AbsolutePath): Promise<T> {

--- a/src/commands/translate/utils/index.ts
+++ b/src/commands/translate/utils/index.ts
@@ -1,5 +1,5 @@
 export type {Locale} from './config';
-export {resolveSchemas, FileLoader, copyAssets} from './fs';
+export {resolveSchemas, FileLoader, copyAssets, languageRepath} from './fs';
 export {extract, compose} from './translate';
 export {resolveSource, resolveTargets, resolveFiles, resolveVars} from './config';
 export {


### PR DESCRIPTION
## Summary

Found while wiring the AI provider to an internal OpenAI-compatible gateway (Eliza / deepseek-v4-flash).

Translation units produced by `extract` are XLIFF `<source>` elements (`<source xml:space="preserve">text with <g>inline</g> tags</source>`), and `compose` selects `<source>` elements from the translated parts via cheerio. The AI provider sent units to the LLM as is, so composing silently depended on the model echoing the XML wrapper back:

- YandexGPT echoed it - everything looked fine;
- deepseek returned clean text (arguably the more correct behavior) - and every file failed with `COMPOSE_ERROR Did not find any translations`.

### Fix

The `<source>` wrapper is transport framing, not translatable content. The provider now strips it before prompting and restores it on the translated text, defensively unwrapping the response in case the model echoes the wrapper anyway. Inline `<g>`/`<x>` placeholder tags still go to the model and are still protected by the prompt rules.

Side effects:

- works with any model regardless of how literally it treats surrounding XML;
- slightly cleaner prompts (no `<source xml:space="preserve">` noise);
- judge pairs and `translate-quality.<lang>.json` now show clean text instead of XML-wrapped segments.

Verified end-to-end against Eliza (`--provider openai --api-base https://api.eliza.yandex.net/raw/internal/deepseek-v4-flash/v1` plus an OAuth header via `--api-header`): before the fix every file failed to compose, after it the smoke project translates cleanly with markup intact.
