### PR TITLE
feat(translate): copy assets into the translated output

### DIFF
--- a/src/commands/translate/config.ts
+++ b/src/commands/translate/config.ts
@@ -111,6 +111,15 @@ const timeout = option({
     parser: Number,
 });
 
+const copyAssets = option({
+    flags: '--copy-assets',
+    desc: `
+        Copy non-translatable files (images and other assets) from the source
+        language directory to the target language directories in the output,
+        so the translated file set is buildable on its own.
+    `,
+});
+
 const useSource = option({
     flags: '--use-source',
     desc: `
@@ -170,6 +179,7 @@ export const options = {
     exclude,
     vars,
     dryRun,
+    copyAssets,
     timeout,
     useSource,
     schema,

--- a/src/commands/translate/index.spec.ts
+++ b/src/commands/translate/index.spec.ts
@@ -279,6 +279,29 @@ describe('Translate command', () => {
             );
         });
 
+        describe('copyAssets', () => {
+            const test = testConfig('--source ru --target en --folder 1 --auth t1.a');
+
+            test('should be disabled by default', '', {
+                copyAssets: false,
+            });
+
+            test('should handle arg', '--copy-assets', {
+                copyAssets: true,
+            });
+
+            test(
+                'should handle config',
+                '',
+                {
+                    copyAssets: true,
+                },
+                {
+                    copyAssets: true,
+                },
+            );
+        });
+
         describe('timeout', () => {
             const test = testConfig('--source ru --target en --folder 1 --auth t1.a');
 

--- a/src/commands/translate/index.ts
+++ b/src/commands/translate/index.ts
@@ -20,7 +20,7 @@ import {Extract} from './commands/extract';
 import {Compose} from './commands/compose';
 import {Extension as YandexTranslation} from './providers/yandex';
 import {Extension as AITranslation} from './providers/ai';
-import {resolveSource, resolveTargets, resolveVars} from './utils';
+import {copyAssets, resolveSource, resolveTargets, resolveVars} from './utils';
 import {Run} from './run';
 import {configDefaults} from './utils/config';
 import {Extension as ExtractOpenapiIncluderFakeExtension} from './extract-openapi';
@@ -40,6 +40,7 @@ export type TranslateArgs = BaseArgs & {
     include?: string[];
     exclude?: string[];
     vars?: Hash;
+    copyAssets?: boolean;
 };
 
 export type TranslateConfig = Pick<BaseArgs, 'input' | 'strict' | 'quiet'> & {
@@ -53,6 +54,7 @@ export type TranslateConfig = Pick<BaseArgs, 'input' | 'strict' | 'quiet'> & {
     skipped: [string, string][];
     vars: Hash;
     dryRun: boolean;
+    copyAssets: boolean;
     timeout: number;
 } & ConfigDefaults;
 
@@ -78,6 +80,7 @@ export class Translate extends BaseProgram<TranslateConfig, TranslateArgs> {
         options.exclude,
         options.vars,
         options.dryRun,
+        options.copyAssets,
         options.timeout,
         options.config(YFM_CONFIG_FILENAME),
     ];
@@ -128,6 +131,7 @@ export class Translate extends BaseProgram<TranslateConfig, TranslateArgs> {
                 vars,
                 provider: defined('provider', args, config),
                 dryRun: defined('dryRun', args, config) || false,
+                copyAssets: defined('copyAssets', args, config) || false,
                 // No global default here: each provider applies its own
                 // (5s for yandex, 60s for LLM providers).
                 timeout: defined('timeout', args, config) as number,
@@ -145,8 +149,13 @@ export class Translate extends BaseProgram<TranslateConfig, TranslateArgs> {
 
         if (this.provider) {
             await this.provider.skip(skipped, this.config);
+            await this.provider.translate(files, this.config);
 
-            return this.provider.translate(files, this.config);
+            if (this.config.copyAssets && !this.config.dryRun) {
+                copyAssets(this.config);
+            }
+
+            return;
         }
 
         // @ts-ignore

--- a/src/commands/translate/run.ts
+++ b/src/commands/translate/run.ts
@@ -16,7 +16,7 @@ import {MarkdownService} from '~/core/markdown';
 
 import {FileLoader, resolveFiles} from './utils';
 
-type CommonRunConfig = Omit<TranslateConfig, 'provider' | 'timeout'> &
+type CommonRunConfig = Omit<TranslateConfig, 'provider' | 'timeout' | 'copyAssets'> &
     ExtractConfig &
     ConfigDefaults;
 

--- a/src/commands/translate/utils/fs.spec.ts
+++ b/src/commands/translate/utils/fs.spec.ts
@@ -1,0 +1,67 @@
+import {existsSync, mkdirSync, mkdtempSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {describe, expect, it} from 'vitest';
+
+import {copyAssets} from './fs';
+
+function makeProject() {
+    const root = mkdtempSync(join(tmpdir(), 'yfm-copy-assets-'));
+    const input = join(root, 'docs');
+    const output = join(root, 'out');
+
+    mkdirSync(join(input, 'ru', '_images'), {recursive: true});
+    writeFileSync(join(input, 'ru', 'index.md'), '# Дока');
+    writeFileSync(join(input, 'ru', 'toc.yaml'), 'title: Дока');
+    writeFileSync(join(input, 'ru', '_images', 'camera.svg'), '<svg/>');
+    writeFileSync(join(input, 'ru', 'logo.png'), 'png');
+
+    return {input, output};
+}
+
+describe('translate copyAssets', () => {
+    it('should copy non-translatable files into the target language directory', () => {
+        const {input, output} = makeProject();
+
+        const copied = copyAssets({
+            input,
+            output,
+            source: {language: 'ru'},
+            target: [{language: 'en'}],
+        });
+
+        expect(copied).toBe(2);
+        expect(existsSync(join(output, 'en', '_images', 'camera.svg'))).toBe(true);
+        expect(existsSync(join(output, 'en', 'logo.png'))).toBe(true);
+        // Translatable files are produced by the translation itself.
+        expect(existsSync(join(output, 'en', 'index.md'))).toBe(false);
+        expect(existsSync(join(output, 'en', 'toc.yaml'))).toBe(false);
+    });
+
+    it('should copy assets for every target language', () => {
+        const {input, output} = makeProject();
+
+        copyAssets({
+            input,
+            output,
+            source: {language: 'ru'},
+            target: [{language: 'en'}, {language: 'de'}],
+        });
+
+        expect(existsSync(join(output, 'en', 'logo.png'))).toBe(true);
+        expect(existsSync(join(output, 'de', 'logo.png'))).toBe(true);
+    });
+
+    it('should do nothing when the source language directory is absent', () => {
+        const {input, output} = makeProject();
+
+        const copied = copyAssets({
+            input,
+            output,
+            source: {language: 'fr'},
+            target: [{language: 'en'}],
+        });
+
+        expect(copied).toBe(0);
+    });
+});

--- a/src/commands/translate/utils/fs.ts
+++ b/src/commands/translate/utils/fs.ts
@@ -1,7 +1,9 @@
 import type {AjvOptions, JSONObject, LinkedJSONObject} from '@diplodoc/translation';
 
-import {dirname, resolve} from 'node:path';
+import {copyFileSync, existsSync, mkdirSync} from 'node:fs';
+import {dirname, extname, join, resolve} from 'node:path';
 import {mkdir, readFile, writeFile} from 'node:fs/promises';
+import {globSync} from 'glob';
 import {load} from 'js-yaml';
 import {stringify} from 'yaml';
 import {linkRefs, unlinkRefs} from '@diplodoc/translation';
@@ -11,6 +13,46 @@ import {
     presetsSchemaJson,
     tocSchemaJson,
 } from '@diplodoc/ajv';
+
+const TRANSLATABLE_EXTENSIONS = ['.md', '.yaml'];
+
+type AssetsConfig = {
+    input: string;
+    output: string;
+    source: {language: string};
+    target: {language: string}[];
+};
+
+/**
+ * Copies non-translatable files (images and other assets) from the source
+ * language directory to the target language directories in the output,
+ * so the translated file set is buildable on its own.
+ *
+ * Returns the number of copied files.
+ */
+export function copyAssets(config: AssetsConfig): number {
+    const from = resolve(config.input, config.source.language);
+    if (!existsSync(from)) {
+        return 0;
+    }
+
+    const assets = globSync('**/*', {cwd: from, nodir: true}).filter(
+        (file) => !TRANSLATABLE_EXTENSIONS.includes(extname(file)),
+    );
+
+    let copied = 0;
+    for (const target of config.target) {
+        const to = resolve(config.output, target.language);
+        for (const asset of assets) {
+            const dest = join(to, asset);
+            mkdirSync(dirname(dest), {recursive: true});
+            copyFileSync(join(from, asset), dest);
+            copied++;
+        }
+    }
+
+    return copied;
+}
 
 function last<T>(array: T[]): T | undefined {
     return array[array.length - 1];

--- a/src/commands/translate/utils/index.ts
+++ b/src/commands/translate/utils/index.ts
@@ -1,5 +1,5 @@
 export type {Locale} from './config';
-export {resolveSchemas, FileLoader} from './fs';
+export {resolveSchemas, FileLoader, copyAssets} from './fs';
 export {extract, compose} from './translate';
 export {resolveSource, resolveTargets, resolveFiles, resolveVars} from './config';
 export {


### PR DESCRIPTION
## Summary

Found during a field trial of the AI translation provider on the Diplodoc docs: the translate output contains only translated `.md`/`.yaml` files. Images and other assets referenced by pages are not copied, so a standalone output directory fails to build:

```
ERR en/vacancy.md: Error: ENOENT: no such file or directory, open '<input>/en/_images/camera.svg'
```

### What's added

`--copy-assets` (or `copyAssets: true` in config): after translation, non-translatable files from the source language directory (`<input>/<source>/`) are copied into every target language directory in the output (`<output>/<target>/`), preserving structure. The translated file set becomes buildable on its own.

- Opt-in: the translate-into-repo flow stays unchanged by default.
- Skipped on `--dry-run`.
- No-op when the project has no per-language source directory.

Verified on diplodoc-platform/docs: `translate --copy-assets` produces an output that `yfm build` assembles without asset errors.
