### PR TITLE
fix(translate): restore missing <source> wrapper in LLM responses

### DIFF
--- a/src/commands/translate/providers/ai/provider.spec.ts
+++ b/src/commands/translate/providers/ai/provider.spec.ts
@@ -224,6 +224,22 @@ describe('translate ai provider', () => {
             expect(client.complete).toHaveBeenCalledTimes(1);
         });
 
+        it('should restore the <source> wrapper when the model strips it', async () => {
+            const unit = '<source xml:space="preserve">Исходный текст</source>';
+            const wrapped = '<source xml:space="preserve">Plain translation</source>';
+            const dir = mkdtempSync(join(tmpdir(), 'yfm-ai-store-'));
+            const store = new TranslationStore(join(dir, 'store.json'), 'fp');
+            store.load();
+            const client = makeClient(() => ['Plain translation']);
+            const {params} = makeParams(client, {maxBatchTokens: 100}, store);
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', [unit]);
+
+            expect(result).toEqual([wrapped]);
+            expect(store.get(unit)).toBe(wrapped);
+        });
+
         it('should retry one-by-one when fragment count mismatches', async () => {
             const client = makeClient((fragments, call) => {
                 // First (batched) response merges everything into one fragment.

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -491,6 +491,12 @@ export function makeTranslator(params: TranslatorParams): Translate {
                         }
                         const translated = await translateWithFallback(path, batch, context);
                         translated.forEach((text, i) => {
+                            // The model occasionally strips the <source> wrapper from
+                            // translated units; compose requires it, so restore it
+                            // before the text reaches the cache or other files.
+                            if (batch[i].includes('<source') && !text.includes('<source')) {
+                                text = `<source xml:space="preserve">${text.trim()}</source>`;
+                            }
                             cache.get(batch[i])?.resolve(text);
                             if (!dryRun) {
                                 store?.set(batch[i], text);


### PR DESCRIPTION
## Problem

The LLM occasionally returns a translated unit without the `<source xml:space="preserve">...</source>` wrapper. The raw response is resolved to concurrent files and persisted into the translation cache as is. Compose is strict about the wrapper (`Did not find any translations` assert in @diplodoc/translation), so a single such unit fails the whole file with COMPOSE_ERROR, and the poisoned cache entry keeps failing every subsequent run that hits it.

Observed on a real run against deepseek-v4-flash: 1583 of 5996 cached units were stored without the wrapper, which failed compose for 92 of 108 files.

## Fix

Normalize the response before it reaches the in-run cache and the persistent store: if the source unit is wrapped and the response is not, restore the wrapper.