### PR TITLE
fix(translate): retry untranslated units and heal poisoned cache entries

### DIFF
--- a/src/commands/translate/providers/ai/provider.spec.ts
+++ b/src/commands/translate/providers/ai/provider.spec.ts
@@ -8,7 +8,14 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {describe, expect, it, vi} from 'vitest';
 
-import {Provider, extractTitle, makeStore, makeTranslator, unwrapUnit} from './provider';
+import {
+    Provider,
+    extractTitle,
+    makeStore,
+    makeTranslator,
+    untranslatedMarker,
+    unwrapUnit,
+} from './provider';
 import {FRAGMENT_SEPARATOR, splitFragments} from './prompts';
 import {LLMAuthError, TranslationStore, cacheFingerprint} from './utils';
 
@@ -284,6 +291,34 @@ describe('translate ai provider', () => {
                 text: 'Просто текст',
                 close: '',
             });
+        });
+    });
+
+    describe('untranslatedMarker', () => {
+        it('should mark source-script text for cross-script pairs', () => {
+            const marker = untranslatedMarker('ru', 'en');
+
+            expect(marker?.test('Привет')).toBe(true);
+            expect(marker?.test('Hello')).toBe(false);
+        });
+
+        it('should not discriminate a Latin source', () => {
+            expect(untranslatedMarker('en', 'ru')).toBeNull();
+        });
+
+        it('should not discriminate same-script pairs', () => {
+            expect(untranslatedMarker('ru', 'uk')).toBeNull();
+        });
+
+        it('should ignore scripts shared with the target', () => {
+            const marker = untranslatedMarker('ja', 'zh');
+
+            expect(marker?.test('ドキュメント')).toBe(true);
+            expect(marker?.test('文档')).toBe(false);
+        });
+
+        it('should disable the check for unknown languages', () => {
+            expect(untranslatedMarker('!!', 'en')).toBeNull();
         });
     });
 

--- a/src/commands/translate/providers/ai/provider.spec.ts
+++ b/src/commands/translate/providers/ai/provider.spec.ts
@@ -13,6 +13,7 @@ import {
     extractTitle,
     makeStore,
     makeTranslator,
+    normalizeCached,
     untranslatedMarker,
     unwrapUnit,
 } from './provider';
@@ -319,6 +320,45 @@ describe('translate ai provider', () => {
 
         it('should disable the check for unknown languages', () => {
             expect(untranslatedMarker('!!', 'en')).toBeNull();
+        });
+    });
+
+    describe('normalizeCached', () => {
+        it('should strip a tilde fence', () => {
+            expect(normalizeCached('Исходный текст', '~~~\nПеревод\n~~~')).toBe('Перевод');
+        });
+
+        it('should strip fences longer than three characters', () => {
+            expect(normalizeCached('Исходный текст', '````\nПеревод\n````')).toBe('Перевод');
+            expect(normalizeCached('Исходный текст', '~~~~~\nПеревод\n~~~~~')).toBe('Перевод');
+        });
+
+        it('should accept a closing fence longer than the opening one', () => {
+            expect(normalizeCached('Исходный текст', '```\nПеревод\n`````')).toBe('Перевод');
+        });
+
+        it('should strip fences with an arbitrary info string', () => {
+            expect(normalizeCached('Исходный текст', '```js title="a.js"\nПеревод\n```')).toBe(
+                'Перевод',
+            );
+        });
+
+        it('should keep fences nested inside a longer wrapper', () => {
+            const stored = '````markdown\nПеревод\n\n```bash\nls\n```\n````';
+
+            expect(normalizeCached('Исходный текст', stored)).toBe('Перевод\n\n```bash\nls\n```');
+        });
+
+        it('should keep an unbalanced fence as is', () => {
+            const shortClose = '````\nПеревод\n```';
+            const otherChar = '```\nПеревод\n~~~';
+
+            expect(normalizeCached('Исходный текст', shortClose)).toBe(shortClose);
+            expect(normalizeCached('Исходный текст', otherChar)).toBe(otherChar);
+        });
+
+        it('should keep a value without a fence as is', () => {
+            expect(normalizeCached('Исходный текст', 'Перевод')).toBe('Перевод');
         });
     });
 

--- a/src/commands/translate/providers/ai/provider.spec.ts
+++ b/src/commands/translate/providers/ai/provider.spec.ts
@@ -43,7 +43,14 @@ function makeParams(
 ) {
     const warn = vi.fn();
     const request = vi.fn();
-    const stat = {inputTokens: 0, outputTokens: 0, requests: 0, bytes: 0, cached: 0};
+    const stat = {
+        inputTokens: 0,
+        outputTokens: 0,
+        requests: 0,
+        bytes: 0,
+        cached: 0,
+        untranslated: 0,
+    };
     const cache = new Map<string, Defer>();
 
     return {
@@ -318,6 +325,112 @@ describe('translate ai provider', () => {
 
             expect(again).toEqual(['T:Same']);
             expect(client.complete).toHaveBeenCalledTimes(1);
+        });
+
+        it('should strip a markdown code fence around the response', async () => {
+            const unit = '<source xml:space="preserve">Исходный текст</source>';
+            const clean = '<source xml:space="preserve">Plain translation</source>';
+            const client = makeClient(() => ['```text\nPlain translation\n```']);
+            const {params} = makeParams(client, {maxBatchTokens: 100});
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', [unit]);
+
+            expect(result).toEqual([clean]);
+        });
+
+        it('should not cache units returned untranslated by the model', async () => {
+            const unit = '<source xml:space="preserve">Исходный текст</source>';
+            const dir = mkdtempSync(join(tmpdir(), 'yfm-ai-store-'));
+            const store = new TranslationStore(join(dir, 'store.json'), 'fp');
+            store.load();
+            const client = makeClient((fragments) => fragments);
+            const {params, warn, stat} = makeParams(client, {maxBatchTokens: 100}, store);
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', [unit]);
+
+            expect(result).toEqual([unit]);
+            expect(store.get(unit)).toBeUndefined();
+            expect(stat.untranslated).toBe(1);
+            expect(warn).toHaveBeenCalledWith(
+                'file.md',
+                'Unit returned untranslated by the model.',
+            );
+        });
+
+        it('should cache identity responses for units without source-script text', async () => {
+            const unit = '<source xml:space="preserve">GitHub API</source>';
+            const dir = mkdtempSync(join(tmpdir(), 'yfm-ai-store-'));
+            const store = new TranslationStore(join(dir, 'store.json'), 'fp');
+            store.load();
+            const client = makeClient((fragments) => fragments);
+            const {params, warn, stat} = makeParams(client, {maxBatchTokens: 100}, store);
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', [unit]);
+
+            expect(result).toEqual([unit]);
+            expect(store.get(unit)).toBe(unit);
+            expect(stat.untranslated).toBe(0);
+            expect(warn).not.toHaveBeenCalled();
+        });
+
+        it('should retry units cached untranslated by older runs', async () => {
+            const unit = '<source xml:space="preserve">Исходный текст</source>';
+            const dir = mkdtempSync(join(tmpdir(), 'yfm-ai-store-'));
+            const store = new TranslationStore(join(dir, 'store.json'), 'fp');
+            store.load();
+            store.set(unit, unit);
+            const client = makeClient(translated);
+            const {params, stat} = makeParams(client, {maxBatchTokens: 100}, store);
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', [unit]);
+
+            const retranslated = '<source xml:space="preserve">T:Исходный текст</source>';
+            expect(client.complete).toHaveBeenCalledTimes(1);
+            expect(result).toEqual([retranslated]);
+            expect(store.get(unit)).toBe(retranslated);
+            expect(stat.cached).toBe(0);
+        });
+
+        it('should heal wrapper noise in cached entries without new requests', async () => {
+            const unit = '<source xml:space="preserve">Исходный текст</source>';
+            const clean = '<source xml:space="preserve">Cached translation</source>';
+            const dir = mkdtempSync(join(tmpdir(), 'yfm-ai-store-'));
+            const store = new TranslationStore(join(dir, 'store.json'), 'fp');
+            store.load();
+            store.set(unit, '```xml\n' + clean + '\n```');
+            const client = makeClient(() => new Error('must not be called'));
+            const {params, stat} = makeParams(client, {maxBatchTokens: 100}, store);
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', [unit]);
+
+            expect(client.complete).not.toHaveBeenCalled();
+            expect(result).toEqual([clean]);
+            expect(store.get(unit)).toBe(clean);
+            expect(stat.cached).toBe(1);
+        });
+
+        it('should heal a <target> wrapper in cached entries', async () => {
+            const unit = '<source xml:space="preserve">Исходный текст</source>';
+            const clean = '<source xml:space="preserve">Cached translation</source>';
+            const dir = mkdtempSync(join(tmpdir(), 'yfm-ai-store-'));
+            const store = new TranslationStore(join(dir, 'store.json'), 'fp');
+            store.load();
+            store.set(unit, '<target>Cached translation</target>');
+            const client = makeClient(() => new Error('must not be called'));
+            const {params, stat} = makeParams(client, {maxBatchTokens: 100}, store);
+            const translate = makeTranslator(params);
+
+            const result = await translate('file.md', [unit]);
+
+            expect(client.complete).not.toHaveBeenCalled();
+            expect(result).toEqual([clean]);
+            expect(store.get(unit)).toBe(clean);
+            expect(stat.cached).toBe(1);
         });
 
         it('should retry one-by-one when fragment count mismatches', async () => {

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -483,10 +483,37 @@ export function untranslatedMarker(sourceLanguage: string, targetLanguage: strin
 /**
  * Models occasionally wrap the whole response in a markdown code fence.
  * The fence is never part of the translation.
+ *
+ * Fences are matched as CommonMark defines them: a run of at least three
+ * backticks or tildes, closed by a run of the same character at least as
+ * long, with an arbitrary info string on the opening line. The model
+ * picks the flavour and the length itself (a longer run when the payload
+ * contains fences of its own), so a fixed three-backtick prefix leaves
+ * the rest of the variants unhandled.
  */
 function stripFence(text: string): string {
-    const fenced = text.match(/^```[a-zA-Z]*\s*\n([\s\S]*?)\n?\s*```$/);
-    return fenced ? fenced[1].trim() : text;
+    const body = text.trim();
+    const open = body.match(/^(`{3,}|~{3,})([^\n]*)\n/);
+
+    if (!open) {
+        return text;
+    }
+
+    const [prefix, markup, info] = open;
+
+    // A backtick fence cannot carry backticks in its info string.
+    if (markup[0] === '`' && info.includes('`')) {
+        return text;
+    }
+
+    const rest = body.slice(prefix.length);
+    const close = rest.match(/(?:^|\n)[ \t]*(`{3,}|~{3,})[ \t]*$/);
+
+    if (!close || close[1][0] !== markup[0] || close[1].length < markup.length) {
+        return text;
+    }
+
+    return rest.slice(0, close.index).trim();
 }
 
 /**

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -428,42 +428,56 @@ export function makeStore(
 }
 
 /**
- * Scripts of languages that do not use the Latin alphabet. Used to tell
- * a refused translation from a legitimately untranslatable unit: when the
- * source and target scripts differ, an identity response for a unit that
- * still contains source-script characters means the model failed to
- * translate it, while identity for code, names or numbers is valid.
+ * CLDR composite script codes (ISO 15924) that are not valid Unicode
+ * script property values: expanded into their component scripts.
  */
-const LANGUAGE_SCRIPTS: [RegExp, string[]][] = [
-    [/[Ѐ-ӿ]/, ['ru', 'uk', 'be', 'bg', 'sr', 'mk', 'kk', 'ky', 'mn']],
-    [/[Ͱ-Ͽ]/, ['el']],
-    [/[֐-׿]/, ['he']],
-    [/[؀-ۿ]/, ['ar', 'fa', 'ur']],
-    [/[ऀ-ॿ]/, ['hi']],
-    [/[一-鿿]/, ['zh']],
-    [/[぀-ヿ一-鿿]/, ['ja']],
-    [/[가-힯]/, ['ko']],
-];
+const COMPOSITE_SCRIPTS: Record<string, string[]> = {
+    Hans: ['Han'],
+    Hant: ['Han'],
+    Jpan: ['Han', 'Hiragana', 'Katakana'],
+    Kore: ['Hangul', 'Han'],
+};
 
-function scriptOf(language: string): RegExp | null {
-    const entry = LANGUAGE_SCRIPTS.find(([, languages]) => languages.includes(language));
-    return entry ? entry[0] : null;
+function scriptsOf(language: string): string[] {
+    try {
+        const script = new Intl.Locale(language).maximize().script;
+        if (!script) {
+            return [];
+        }
+
+        return COMPOSITE_SCRIPTS[script] || [script];
+    } catch {
+        return [];
+    }
 }
 
 /**
  * Returns a regexp matching source-script characters that must not survive
- * translation, or null when the pair cannot be discriminated by script
- * (e.g. Latin to Latin) and identity responses have to be trusted.
+ * translation, or null when the pair cannot be discriminated by script and
+ * identity responses have to be trusted. The script of a language comes
+ * from the CLDR likely-subtags data, so any language known to the runtime
+ * is supported. Scripts shared with the target do not discriminate (e.g.
+ * only kana counts for ja -> zh). A Latin source never discriminates:
+ * code, identifiers and product names are Latin in documents of any
+ * language, so a Latin identity response cannot be told apart from a
+ * legitimately untranslatable unit.
  */
 export function untranslatedMarker(sourceLanguage: string, targetLanguage: string): RegExp | null {
-    const source = scriptOf(sourceLanguage);
-    const target = scriptOf(targetLanguage);
+    const target = new Set(scriptsOf(targetLanguage));
+    const source = scriptsOf(sourceLanguage).filter(
+        (script) => script !== 'Latn' && !target.has(script),
+    );
 
-    if (!source || source === target) {
+    if (!source.length) {
         return null;
     }
 
-    return source;
+    try {
+        return new RegExp(source.map((script) => `\\p{Script=${script}}`).join('|'), 'u');
+    } catch {
+        // Script codes unknown to the regexp engine disable the check.
+        return null;
+    }
 }
 
 /**

--- a/src/commands/translate/providers/ai/provider.ts
+++ b/src/commands/translate/providers/ai/provider.ts
@@ -66,7 +66,14 @@ export class Provider {
         try {
             for (const target of targets) {
                 const cache = new Map<string, Defer>();
-                const stat = {inputTokens: 0, outputTokens: 0, requests: 0, bytes: 0, cached: 0};
+                const stat = {
+                    inputTokens: 0,
+                    outputTokens: 0,
+                    requests: 0,
+                    bytes: 0,
+                    cached: 0,
+                    untranslated: 0,
+                };
                 const store = makeStore(client, config, source.language, target.language);
 
                 store?.load();
@@ -140,7 +147,7 @@ export class Provider {
                 this.logger.stat(
                     `requests: ${stat.requests} input-tokens: ${stat.inputTokens} ` +
                         `output-tokens: ${stat.outputTokens} bytes: ${stat.bytes} ` +
-                        `cached-units: ${stat.cached}`,
+                        `cached-units: ${stat.cached} untranslated-units: ${stat.untranslated}`,
                 );
 
                 if (pairs.length) {
@@ -376,6 +383,7 @@ type TranslatorParams = {
         requests: number;
         bytes: number;
         cached: number;
+        untranslated: number;
     };
     logger: TranslateLogger;
 };
@@ -419,6 +427,80 @@ export function makeStore(
     return new TranslationStore(file, fingerprint);
 }
 
+/**
+ * Scripts of languages that do not use the Latin alphabet. Used to tell
+ * a refused translation from a legitimately untranslatable unit: when the
+ * source and target scripts differ, an identity response for a unit that
+ * still contains source-script characters means the model failed to
+ * translate it, while identity for code, names or numbers is valid.
+ */
+const LANGUAGE_SCRIPTS: [RegExp, string[]][] = [
+    [/[Ѐ-ӿ]/, ['ru', 'uk', 'be', 'bg', 'sr', 'mk', 'kk', 'ky', 'mn']],
+    [/[Ͱ-Ͽ]/, ['el']],
+    [/[֐-׿]/, ['he']],
+    [/[؀-ۿ]/, ['ar', 'fa', 'ur']],
+    [/[ऀ-ॿ]/, ['hi']],
+    [/[一-鿿]/, ['zh']],
+    [/[぀-ヿ一-鿿]/, ['ja']],
+    [/[가-힯]/, ['ko']],
+];
+
+function scriptOf(language: string): RegExp | null {
+    const entry = LANGUAGE_SCRIPTS.find(([, languages]) => languages.includes(language));
+    return entry ? entry[0] : null;
+}
+
+/**
+ * Returns a regexp matching source-script characters that must not survive
+ * translation, or null when the pair cannot be discriminated by script
+ * (e.g. Latin to Latin) and identity responses have to be trusted.
+ */
+export function untranslatedMarker(sourceLanguage: string, targetLanguage: string): RegExp | null {
+    const source = scriptOf(sourceLanguage);
+    const target = scriptOf(targetLanguage);
+
+    if (!source || source === target) {
+        return null;
+    }
+
+    return source;
+}
+
+/**
+ * Models occasionally wrap the whole response in a markdown code fence.
+ * The fence is never part of the translation.
+ */
+function stripFence(text: string): string {
+    const fenced = text.match(/^```[a-zA-Z]*\s*\n([\s\S]*?)\n?\s*```$/);
+    return fenced ? fenced[1].trim() : text;
+}
+
+/**
+ * Normalizes a translation cached by older CLI versions, which stored raw
+ * model responses: strips markdown fences, converts a `<target>` echo into
+ * the canonical `<source>` wrapper and restores a stripped wrapper.
+ *
+ * Returns the unit text unchanged when the cached value is not a
+ * translation at all (the model echoed the source back) - callers treat
+ * that as a cache miss so the unit gets retried.
+ */
+export function normalizeCached(unit: string, stored: string): string {
+    let result = stripFence(stored.trim());
+
+    if (unit.includes(SOURCE_OPEN)) {
+        const target = result.match(/^<target(?:\s[^>]*)?>([\s\S]*)<\/target>$/);
+        if (target) {
+            result = target[1].trim();
+        }
+
+        if (!result.includes(SOURCE_OPEN)) {
+            result = `<source xml:space="preserve">${result}</source>`;
+        }
+    }
+
+    return result;
+}
+
 export function makeTranslator(params: TranslatorParams): Translate {
     const {client, config, sourceLanguage, targetLanguage, cache, store, stat, logger} = params;
     const {
@@ -435,6 +517,7 @@ export function makeTranslator(params: TranslatorParams): Translate {
     } = config;
 
     const schedule = scheduler(maxConcurrency);
+    const marker = untranslatedMarker(sourceLanguage, targetLanguage);
 
     async function translateBatch(fragments: string[], context: string): Promise<string[]> {
         if (!fragments.length) {
@@ -499,7 +582,7 @@ export function makeTranslator(params: TranslatorParams): Translate {
         // the source text instead (matches the built-in prompt rules).
         return parts.map((part, index) => {
             const {open, text, close} = wrappers[index];
-            return open + (unwrapUnit(part).text || text) + close;
+            return open + (unwrapUnit(stripFence(part)).text || text) + close;
         });
     }
 
@@ -549,6 +632,15 @@ export function makeTranslator(params: TranslatorParams): Translate {
                         }
                         const translated = await translateWithFallback(path, batch, context);
                         translated.forEach((text, i) => {
+                            if (!dryRun && text === batch[i] && marker?.test(text)) {
+                                // The model returned source-script text unchanged.
+                                // Keep it out of the store so the next run retries,
+                                // and surface the miss in the stats.
+                                stat.untranslated++;
+                                logger.warn(path, 'Unit returned untranslated by the model.');
+                                cache.get(batch[i])?.resolve(text);
+                                return;
+                            }
                             cache.get(batch[i])?.resolve(text);
                             if (!dryRun) {
                                 store?.set(batch[i], text);
@@ -586,9 +678,20 @@ export function makeTranslator(params: TranslatorParams): Translate {
 
             const stored = store?.get(text);
             if (stored !== undefined) {
-                stat.cached++;
-                promises.push(Promise.resolve(stored));
-                continue;
+                const normalized = normalizeCached(text, stored);
+                // Identity entries for units that still contain source-script
+                // characters were cached by older runs that stored untranslated
+                // responses. Treat them as misses so the unit gets another chance.
+                const refused = normalized === text && marker !== null && marker.test(text);
+                if (!refused) {
+                    if (normalized !== stored) {
+                        // Heal wrapper noise cached by older runs.
+                        store?.set(text, normalized);
+                    }
+                    stat.cached++;
+                    promises.push(Promise.resolve(normalized));
+                    continue;
+                }
             }
 
             const cached = cache.get(text);


### PR DESCRIPTION
## Problem

Found while translating diplodoc-platform/docs ru -> en through an OpenAI-compatible gateway (deepseek), follow-up to #2159.

The AI provider trusts every model response and every cache entry unconditionally, which lets two kinds of noise become permanent:

- When the model returns the source text unchanged (it occasionally refuses to translate a unit), the identity response is cached as a valid translation and the unit silently stays in the source language forever. The judge report cannot catch this: it only scores pairs where the translation differs from the source. On a real documentation run this produced dozens of half-Russian pages with no diagnostics at all.
- Caches written by older CLI versions may contain raw model responses wrapped in markdown code fences or a `<target>` element. Every warm run then fails with `COMPOSE_ERROR (Did not find any translations)` on fully cached files, and the suggested remedy (re-run and let the cache finish the tails) makes things worse because the cache itself is the source of the error.

## Changes

- An identity response is treated as a refusal only when the unit still contains source-script characters (e.g. Cyrillic for ru -> en). Code, names and already-English text legitimately survive translation unchanged and stay cacheable, so warm runs do not re-request them. Same-script pairs (e.g. en -> fr) cannot be discriminated this way and keep the previous trusting behavior.
- Refused units are kept out of the store so the next run retries them, each is surfaced with a per-unit warning, and the total is added to the PROCESSED stats line as `untranslated-units`.
- Cached entries are normalized on read: fence and `<target>` noise is healed in place, identity entries for units with source-script text are treated as cache misses. Existing poisoned caches self-heal without manual intervention.
- Responses are defensively unfenced before the wrapper is restored.

## Verification on real docs

Warm-cache run over diplodoc-platform/docs (107 files, ~5.5k units) with a cache poisoned by earlier CLI versions:

- before: 91 files failed with COMPOSE_ERROR, mixed-language pages invisible in stats
- after: 0 errors, poisoned entries healed on read, `untranslated-units: 1` (a unit the model persistently refuses to translate; it is retried on every run and costs one request)