### PR TITLE
chore(deps): bump @diplodoc/translation to 1.7.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@diplodoc/color-extension": "^1.0.0",
         "@diplodoc/liquid": "^1.5.3",
         "@diplodoc/transform": "^4.77.11",
-        "@diplodoc/translation": "^1.7.29",
+        "@diplodoc/translation": "^1.7.30",
         "@diplodoc/utils": "^2.3.6",
         "@gravity-ui/uikit-themer": "^1.7.0",
         "@inquirer/prompts": "^8.3.2",
@@ -2087,12 +2087,13 @@
       }
     },
     "node_modules/@diplodoc/translation": {
-      "version": "1.7.29",
-      "resolved": "https://registry.npmjs.org/@diplodoc/translation/-/translation-1.7.29.tgz",
-      "integrity": "sha512-pE/AUvdTx2D7XYUupJ2n3/b/yEzxT6GXqL6cFFbGXX8JSRMM5W+yvzfUdKUX2JZwu2Mbzkn86xFomys7QUP62g==",
+      "version": "1.7.30",
+      "resolved": "https://registry.npmjs.org/@diplodoc/translation/-/translation-1.7.30.tgz",
+      "integrity": "sha512-PovcE5ZA9KvSJLxgCo2JUQ2iQ1diucpDb/cqorIoi3sx+We+GyOHuOd3bCT+3qLOT5i+3kO3tJ5KlQVWToTERw==",
       "license": "MIT",
       "dependencies": {
         "@cospired/i18n-iso-languages": "^4.1.0",
+        "@diplodoc/ajv": "^0.4.1",
         "@diplodoc/directive": "^0.3.6",
         "@diplodoc/sentenizer": "^0.0.11",
         "@diplodoc/transform": "^4.77.5",
@@ -2113,7 +2114,8 @@
         "ts-dedent": "^2.2.0",
         "uri-js": "^4.4.1",
         "xml-formatter": "^3.6.1",
-        "xml-parser-xo": "^4.1.1"
+        "xml-parser-xo": "^4.1.1",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=24",
@@ -18638,15 +18640,18 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@diplodoc/color-extension": "^1.0.0",
     "@diplodoc/liquid": "^1.5.3",
     "@diplodoc/transform": "^4.77.11",
-    "@diplodoc/translation": "^1.7.29",
+    "@diplodoc/translation": "^1.7.30",
     "@diplodoc/utils": "^2.3.6",
     "@gravity-ui/uikit-themer": "^1.7.0",
     "@inquirer/prompts": "^8.3.2",


### PR DESCRIPTION
Brings diplodoc-platform/translation#275: yaml-aware extraction of page-constructor blocks (diplodoc-platform/translation#273).

Translatable values inside `::: page-constructor` blocks are now addressed by exact node positions and extracted as separate units, so LLM translation no longer corrupts the yaml structure and such pages do not need to be excluded from translation runs.

Verified on diplodoc-platform/docs: `ru/project/page-constructor.md` translates without `--exclude`, the composed block parses as valid yaml.