### PR TITLE
fix(translate): send the glossary to Yandex Translate and stop double requests

### DIFF
--- a/src/commands/translate/providers/yandex/provider.spec.ts
+++ b/src/commands/translate/providers/yandex/provider.spec.ts
@@ -82,6 +82,15 @@ describe('translate yandex provider', () => {
         });
     });
 
+    it('should send a single request per batch', async () => {
+        const config = makeConfig([]);
+        const provider = new Provider(config);
+
+        await provider.translate(['ru/index.md'], config);
+
+        expect(request).toHaveBeenCalledOnce();
+    });
+
     it('should not send glossary config when glossary is not configured', async () => {
         const config = makeConfig([]);
         const provider = new Provider(config);

--- a/src/commands/translate/providers/yandex/provider.spec.ts
+++ b/src/commands/translate/providers/yandex/provider.spec.ts
@@ -1,0 +1,97 @@
+import type {Mock} from 'vitest';
+import type {TranslateConfig} from '~/commands/translate';
+import type {YandexTranslationConfig} from '.';
+
+import {mkdirSync, mkdtempSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import axios from 'axios';
+
+import {Provider} from './provider';
+
+vi.mock('axios', async (importOriginal) => {
+    const actual = (await importOriginal()) as {default: object};
+
+    return {
+        ...actual,
+        default: vi.fn(),
+    };
+});
+
+const request = axios as unknown as Mock;
+
+type GlossaryPair = {sourceText: string; translatedText: string};
+
+function makeProject() {
+    const root = mkdtempSync(join(tmpdir(), 'yfm-translate-yandex-'));
+    const input = join(root, 'docs');
+    const output = join(root, 'out');
+
+    mkdirSync(join(input, 'ru'), {recursive: true});
+    writeFileSync(join(input, 'ru', 'index.md'), 'Сборка документации.');
+
+    return {input, output};
+}
+
+function makeConfig(glossaryPairs: GlossaryPair[]) {
+    const {input, output} = makeProject();
+
+    return {
+        input,
+        output,
+        auth: 'Bearer token',
+        folder: 'folder',
+        source: {language: 'ru', locale: 'RU'},
+        target: [{language: 'en', locale: 'US'}],
+        vars: {},
+        dryRun: false,
+        timeout: 1000,
+        quiet: true,
+        glossaryPairs,
+    } as unknown as TranslateConfig & YandexTranslationConfig;
+}
+
+describe('translate yandex provider', () => {
+    beforeEach(() => {
+        request.mockReset();
+        // Echo the source texts back: the request payload is what matters here,
+        // and compose needs a translation for every extracted unit.
+        request.mockImplementation(async ({data}: {data: {texts: string[]}}) => ({
+            data: {translations: data.texts.map((text) => ({text}))},
+        }));
+        vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+            throw new Error(`Unexpected process.exit(${code})`);
+        }) as never);
+    });
+
+    it('should send configured glossary pairs with the translation request', async () => {
+        const config = makeConfig([{sourceText: 'сборка', translatedText: 'build'}]);
+        const provider = new Provider(config);
+
+        await provider.translate(['ru/index.md'], config);
+
+        expect(request).toHaveBeenCalled();
+
+        const [{data}] = request.mock.calls[0];
+
+        expect(data.glossaryConfig).toEqual({
+            glossaryData: {
+                glossaryPairs: [{sourceText: 'сборка', translatedText: 'build'}],
+            },
+        });
+    });
+
+    it('should not send glossary config when glossary is not configured', async () => {
+        const config = makeConfig([]);
+        const provider = new Provider(config);
+
+        await provider.translate(['ru/index.md'], config);
+
+        expect(request).toHaveBeenCalled();
+
+        const [{data}] = request.mock.calls[0];
+
+        expect(data.glossaryConfig).toBeUndefined();
+    });
+});

--- a/src/commands/translate/providers/yandex/provider.ts
+++ b/src/commands/translate/providers/yandex/provider.ts
@@ -393,6 +393,7 @@ async function backoff(action: () => Promise<void>): Promise<void> {
     while (++retry < RETRY_LIMIT) {
         try {
             await action();
+            return;
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
             if (RequestError.canRetry(error)) {

--- a/src/commands/translate/providers/yandex/provider.ts
+++ b/src/commands/translate/providers/yandex/provider.ts
@@ -56,6 +56,7 @@ export class Provider {
             vars,
             dryRun,
             timeout,
+            glossaryPairs = [],
         } = config;
 
         try {
@@ -66,7 +67,7 @@ export class Provider {
                     auth,
                     sourceLanguage: source.language,
                     targetLanguage: target.language,
-                    // yandexCloudTranslateGlossaryPairs,
+                    glossaryPairs,
                     folderId: folder,
                     vars,
                     dryRun,
@@ -118,13 +119,14 @@ export class Provider {
     }
 }
 
+type GlossaryPairs = YandexTranslationConfig['glossaryPairs'];
+
 type TranslatorParams = {
     input: string;
     output: string;
     sourceLanguage: string;
     targetLanguage: string;
     vars: Hash;
-    // yandexCloudTranslateGlossaryPairs: YandexCloudTranslateGlossaryPair[];
 };
 
 type RequesterParams = {
@@ -134,6 +136,7 @@ type RequesterParams = {
     targetLanguage: string;
     dryRun: boolean;
     timeout: number;
+    glossaryPairs: GlossaryPairs;
 };
 
 type Request = {
@@ -190,8 +193,10 @@ function scheduler(limit: number, interval: number) {
 }
 
 function requester(params: RequesterParams, cache: Cache) {
-    const {auth, folderId, sourceLanguage, targetLanguage, dryRun, timeout} = params;
+    const {auth, folderId, sourceLanguage, targetLanguage, dryRun, timeout, glossaryPairs} = params;
     const schedule = scheduler(REQUESTS_LIMIT, 1000);
+    // The API rejects an empty glossary, so the field is omitted without pairs.
+    const glossaryConfig = glossaryPairs.length ? {glossaryData: {glossaryPairs}} : undefined;
 
     const request = function request(texts: string[]) {
         const resolve = (text: string, index: number) => {
@@ -228,6 +233,7 @@ function requester(params: RequesterParams, cache: Cache) {
                             sourceLanguageCode: sourceLanguage,
                             targetLanguageCode: targetLanguage,
                             format: 'HTML',
+                            glossaryConfig,
                         },
                     }),
                 );


### PR DESCRIPTION
Две правки в провайдере `yandex` команды `translate`.

### Глоссарий не доезжал до API

`--glossary` резолвился в `config.glossaryPairs`, но в тело запроса пары не попадали: поле было закомментировано со времён перевода команд на extension api (7a2e3fc7, апрель 2024). Опция молча ничего не делала - на странице локализации она при этом задокументирована как рабочая.

Пары прокинуты в `requester` и уходят как `glossaryConfig.glossaryData.glossaryPairs`. Без глоссария поле не отправляется: API принимает от 1 до 50 пар и пустой список отклоняет.

### Каждый батч уходил дважды

В `backoff()` не было `return` после успешного вызова, поэтому `while (++retry < RETRY_LIMIT)` всегда выполнял действие два раза: каждый батч текстов отправлялся в Yandex Translate и оплачивался дважды.

### Остаётся как есть

Если ретраи исчерпаны, `backoff()` завершается молча, и промисы юнитов остаются нерезолвленными - перевод повиснет вместо ошибки. Поведение не новое, трогать в этом PR не стал.